### PR TITLE
Base-template API and gallery UI refactor

### DIFF
--- a/src/api/services/TemplateFieldsAPI.ts
+++ b/src/api/services/TemplateFieldsAPI.ts
@@ -8,8 +8,6 @@ export class TemplateFieldsAPI extends BaseAPI {
   }
 
   async getTemplateFields() {
-    console.log('here ===========================>');
-    
     try {
       const response = await this.get<CBTemplateFieldContentIdMapping[]>(
         `/field-content-mappings`

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -3,3 +3,9 @@ export { default as SharedTemplateTable } from './shared-table';
 export * from './tag-displayer';
 export { default as DeviceSelector } from './device-selector';
 export { ShopperSelector, default as DefaultShopperSelector } from './shopper-selector';
+
+// Template preview components
+export { BrowserPreview, BrowserPreviewSkeleton } from './template-preview/BrowserPreview';
+export { BrowserPreviewModal } from './template-preview/BrowserPreviewModal';
+export { PopupOnlyView } from './template-preview/PopupOnlyView';
+export { PopupPreviewTabs } from './template-preview/PopupPreviewTabs';

--- a/src/components/common/template-preview/BrowserPreview.tsx
+++ b/src/components/common/template-preview/BrowserPreview.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useRef } from 'react';
-import type { BrowserPreviewProps } from '../types/clientFlow';
+import type { BrowserPreviewProps } from '../../../features/client-flow/types/clientFlow';
 import { Safari } from '@/components/magicui/safari';
 import Android from '@/components/magicui/android';
 import { safeDecodeAndSanitizeHtml } from '@/lib/utils/helper';

--- a/src/components/common/template-preview/BrowserPreviewModal.tsx
+++ b/src/components/common/template-preview/BrowserPreviewModal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Modal } from 'antd';
-import { BrowserPreview } from './BrowserPreview';
-import type { WebsiteData } from '../types/clientFlow';
+import { BrowserPreview } from '../index';
+import type { WebsiteData } from '../../../features/client-flow/types/clientFlow';
 
 interface BrowserPreviewModalProps {
   open: boolean;
@@ -20,7 +20,7 @@ export const BrowserPreviewModal: React.FC<BrowserPreviewModalProps> = ({
 }) => {
   return (
     <Modal
-      title={`Browser Preview - ${viewport === 'desktop' ? 'Desktop' : 'Mobile'}`}
+      title={`${viewport === 'desktop' ? 'Desktop' : 'Mobile'} Preview`}
       open={open}
       onCancel={onClose}
       footer={null}

--- a/src/components/common/template-preview/PopupOnlyView.tsx
+++ b/src/components/common/template-preview/PopupOnlyView.tsx
@@ -3,7 +3,7 @@ import { safeDecodeAndSanitizeHtml } from '@/lib/utils/helper';
 import { useOptimizedHTMLMerger } from '@/lib/hooks';
 import { ReminderTabConfig } from '@/features/builder/types';
 import { Spin } from 'antd';
-import { useFieldHighlight } from '../hooks/use-field-highlight';
+import { useFieldHighlight } from '../../../features/client-flow/hooks/use-field-highlight';
 import { useClientFlowStore } from '@/stores/clientFlowStore';
 import { templateContentParser, ContentMapping } from '@/lib/utils/template-content-parser';
 

--- a/src/components/common/template-preview/PopupPreviewTabs.tsx
+++ b/src/components/common/template-preview/PopupPreviewTabs.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Tabs, Card, Typography } from 'antd';
 import { MonitorSpeaker, Smartphone } from 'lucide-react';
-import { PopupOnlyView } from './PopupOnlyView';
+import { PopupOnlyView } from '../index';
 import { ClientFlowData } from '@/types';
 
 const { Title } = Typography;
@@ -27,7 +27,7 @@ export const PopupPreviewTabs: React.FC<PopupPreviewTabsProps> = ({
       const mobile = clientData.find(
         (t) => t.devices.some((device) => device.device_type === 'mobile')
       );
-      
+
       setDesktopTemplate(desktop || null);
       setMobileTemplate(mobile || null);
     }

--- a/src/components/skeletons/base-template-card-skeleton.tsx
+++ b/src/components/skeletons/base-template-card-skeleton.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Card, Skeleton, Space } from 'antd';
+
+const BaseTemplateCardSkeleton = () => {
+  return (
+    <Card
+      actions={[
+        <Skeleton.Button key="action1" active size="small" style={{ width: 24, height: 24 }} />,
+        <Skeleton.Button key="action2" active size="small" style={{ width: 24, height: 24 }} />,
+        <Skeleton.Button key="action3" active size="small" style={{ width: 24, height: 24 }} />,
+      ]}
+    >
+      <Card.Meta
+        title={<Skeleton.Input active style={{ width: '80%', height: 20 }} />}
+        description={
+          <Space direction="vertical" style={{ width: '100%' }} size="small">
+            <Skeleton
+              paragraph={{ rows: 2, width: ['100%', '85%'] }}
+              title={false}
+              active
+            />
+            <Space size="small">
+              <Skeleton.Button active size="small" style={{ width: 60, height: 22 }} />
+              <Skeleton.Button active size="small" style={{ width: 80, height: 22 }} />
+            </Space>
+          </Space>
+        }
+      />
+    </Card>
+  );
+};
+
+export default BaseTemplateCardSkeleton;

--- a/src/components/skeletons/index.ts
+++ b/src/components/skeletons/index.ts
@@ -1,1 +1,2 @@
 export { default as ShopperDescriptionSkeleton } from './shopper-description-skeleton';
+export { default as BaseTemplateCardSkeleton } from './base-template-card-skeleton';

--- a/src/features/base-template/components/BaseTemplateCard.tsx
+++ b/src/features/base-template/components/BaseTemplateCard.tsx
@@ -1,0 +1,203 @@
+import React, { useState, useEffect } from 'react';
+import { Card, Tag, Space, Tooltip, Popconfirm, Dropdown, MenuProps, Modal, Spin } from 'antd';
+import { EditOutlined, EyeOutlined, DeleteOutlined, FolderOutlined } from '@ant-design/icons';
+import { BaseTemplate } from '../types';
+import { Typography } from 'antd';
+import { PopupPreviewTabs } from '@/components/common';
+import { useTemplatePreviewData } from '@/lib/hooks';
+import { convertUnlayerJsonToHtml, validateUnlayerDesign } from '@/lib/utils/unlayerHtmlConverter';
+import { useLoadingStore } from '@/stores/common/loading.store';
+
+const { Text } = Typography;
+
+interface BaseTemplateCardProps {
+  template: BaseTemplate;
+  onEditTemplate: (template: BaseTemplate) => void;
+  onPreviewTemplate: (template: BaseTemplate) => void;
+  onDeleteTemplate: (template: BaseTemplate) => void;
+  onUpdateStatus?: (template: BaseTemplate, status: 'archive' | 'active' | 'deleted') => Promise<void>;
+  getStatusColor: (status: string) => string;
+  getAvailableStatuses: (currentStatus: string) => Array<'archive' | 'active' | 'deleted'>;
+}
+
+export const BaseTemplateCard: React.FC<BaseTemplateCardProps> = ({
+  template,
+  onEditTemplate,
+  onDeleteTemplate,
+  onUpdateStatus,
+  getStatusColor,
+  getAvailableStatuses,
+}) => {
+  const [pendingStatusChange, setPendingStatusChange] = useState<{
+    newStatus: 'archive' | 'active' | 'deleted';
+  } | null>(null);
+  const [previewModalVisible, setPreviewModalVisible] = useState(false);
+  const [previewHtml, setPreviewHtml] = useState<string | null>(null);
+  const [loadingConversion, setLoadingConversion] = useState(false);
+  const { baseTemplateStatusUpdate } = useLoadingStore();
+
+  // Convert builder_state_json to HTML when preview modal opens (same parser as template listing flow)
+  useEffect(() => {
+    if (!previewModalVisible) {
+      setPreviewHtml(null);
+      return;
+    }
+    const designJson = template.builder_state_json;
+    if (!designJson || !validateUnlayerDesign(designJson)) {
+      setPreviewHtml(null);
+      return;
+    }
+    setLoadingConversion(true);
+    convertUnlayerJsonToHtml(designJson)
+      .then((html) => {
+        setPreviewHtml(html);
+      })
+      .catch((err) => {
+        console.error('Failed to convert builder_state_json to HTML for preview:', err);
+        setPreviewHtml(null);
+      })
+      .finally(() => {
+        setLoadingConversion(false);
+      });
+  }, [previewModalVisible, template.template_id, template.builder_state_json]);
+
+  // Only pass templateId + htmlContent once preview HTML is ready so the hook never runs with null htmlContent
+  const previewReady = previewModalVisible && !!previewHtml;
+  const { previewData, loading: loadingPreview } = useTemplatePreviewData({
+    templateId: previewReady ? template.template_id : null,
+    htmlContent: previewHtml || undefined,
+    enabled: previewReady,
+    template: template
+  });
+
+  const handleStatusConfirm = async () => {
+    if (pendingStatusChange && onUpdateStatus) {
+      await onUpdateStatus(template, pendingStatusChange.newStatus);
+      setPendingStatusChange(null);
+    }
+  };
+
+  const getStatusMenuItems = (): MenuProps['items'] => {
+    const availableStatuses = getAvailableStatuses(template.status);
+    
+    return availableStatuses.map((status) => ({
+      key: status,
+      label: status.charAt(0).toUpperCase() + status.slice(1),
+      onClick: () => {
+        setPendingStatusChange({ newStatus: status });
+      },
+    }));
+  };
+  return (
+    <Card
+      hoverable
+      actions={[
+        <Tooltip title="Edit" key="edit">
+          <EditOutlined onClick={() => onEditTemplate(template)} />
+        </Tooltip>,
+        <Tooltip title="Preview" key="preview">
+          <EyeOutlined onClick={() => setPreviewModalVisible(true)} />
+        </Tooltip>,
+        <Popconfirm
+          key="delete"
+          title="Delete Template"
+          description={`Are you sure you want to delete "${template.name}"?`}
+          onConfirm={() => onDeleteTemplate(template)}
+          okText="Yes, Delete"
+          cancelText="Cancel"
+          okButtonProps={{ danger: true }}
+        >
+          <Tooltip title="Delete">
+            <DeleteOutlined style={{ color: '#ff4d4f' }} />
+          </Tooltip>
+        </Popconfirm>,
+      ]}
+    >
+      <Card.Meta
+        title={
+          <Tooltip title={template.name}>
+            <div
+              style={{
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {template.name}
+            </div>
+          </Tooltip>
+        }
+        description={
+          <Space direction="vertical" style={{ width: '100%' }}>
+            {template.description && (
+              <Text
+                type="secondary"
+                style={{
+                  fontSize: 12,
+                  display: '-webkit-box',
+                  WebkitLineClamp: 2,
+                  WebkitBoxOrient: 'vertical',
+                  overflow: 'hidden',
+                }}
+              >
+                {template.description}
+              </Text>
+            )}
+            <Space size="small">
+              <Popconfirm
+                title={`Change Status to ${pendingStatusChange?.newStatus ? pendingStatusChange.newStatus.charAt(0).toUpperCase() + pendingStatusChange.newStatus.slice(1) : ''}?`}
+                description={`Are you sure you want to change the status of "${template.name}" to ${pendingStatusChange?.newStatus}?`}
+                open={pendingStatusChange !== null}
+                onConfirm={handleStatusConfirm}
+                onCancel={() => setPendingStatusChange(null)}
+                okText="Yes, Update"
+                cancelText="Cancel"
+                okButtonProps={{ danger: pendingStatusChange?.newStatus === 'deleted', loading: baseTemplateStatusUpdate }}
+                placement="top"
+              >
+                <Dropdown
+                  menu={{ items: getStatusMenuItems() }}
+                  trigger={['click']}
+                  disabled={!onUpdateStatus}
+                >
+                  <Tag
+                    color={getStatusColor(template.status)}
+                    style={{ cursor: onUpdateStatus ? 'pointer' : 'default' }}
+                  >
+                    {template.status.charAt(0).toUpperCase() + template.status.slice(1)}
+                  </Tag>
+                </Dropdown>
+              </Popconfirm>
+              {template.category && (
+                <Tag icon={<FolderOutlined />}>
+                  {template.category.name}
+                </Tag>
+              )}
+            </Space>
+          </Space>
+        }
+      />
+      <Modal
+        open={previewModalVisible}
+        onCancel={() => setPreviewModalVisible(false)}
+        footer={null}
+        width={1200}
+        centered
+        destroyOnHidden
+      >
+        <div className="py-4">
+          {loadingConversion || loadingPreview ? (
+            <div className="flex items-center justify-center h-96">
+              <Spin size="large" />
+            </div>
+          ) : (
+            <PopupPreviewTabs
+              clientData={previewData}
+              className="w-full"
+            />
+          )}
+        </div>
+      </Modal>
+    </Card>
+  );
+};

--- a/src/features/base-template/components/BaseTemplateConfig.tsx
+++ b/src/features/base-template/components/BaseTemplateConfig.tsx
@@ -1,19 +1,20 @@
-import { Button, Card, Form, Input, InputNumber, Select, Space, Switch } from 'antd';
+import { Button, Card, Form, Input, InputNumber, Select, Space, Switch, Row, Col, FormInstance } from 'antd';
 import React, { useEffect } from 'react';
 import { useBaseTemplateStore, useCategoryStore } from '../stores';
-import { ArrowLeftCircle } from 'lucide-react';
+import { useLoadingStore } from '@/stores/common/loading.store';
 
 const { TextArea } = Input;
 
 interface BaseTemplateConfigProps {
   onCancel: () => void;
   handleNextStep: () => void;
+  form: FormInstance<any>;
 }
 
-const BaseTemplateConfig: React.FC<BaseTemplateConfigProps> = ({ onCancel, handleNextStep }) => {
-  const [form] = Form.useForm();
+const BaseTemplateConfig: React.FC<BaseTemplateConfigProps> = ({ onCancel, handleNextStep, form }) => {
   const { categories } = useCategoryStore();
   const { selectedCategoryId } = useBaseTemplateStore();
+  const { baseTemplateConfigCreation } = useLoadingStore();
 
   useEffect(() => {
     if (selectedCategoryId) {
@@ -22,7 +23,7 @@ const BaseTemplateConfig: React.FC<BaseTemplateConfigProps> = ({ onCancel, handl
   }, [selectedCategoryId, form]);
 
   return (
-    <>
+    <div className="max-w-2xl mx-auto">
       <Card>
         <Form
           form={form}
@@ -31,60 +32,74 @@ const BaseTemplateConfig: React.FC<BaseTemplateConfigProps> = ({ onCancel, handl
             category_id: selectedCategoryId,
           }}
         >
-          <Form.Item
-            name="name"
-            label="Template Name"
-            rules={[
-              { required: true, message: 'Please enter template name' },
-              { max: 200, message: 'Name must be less than 200 characters' },
-            ]}
-          >
-            <Input placeholder="e.g., Summer Sale Template" />
-          </Form.Item>
+          <Row gutter={[16, 0]}>
+            <Col xs={24}>
+              <Form.Item
+                name="name"
+                label="Template Name"
+                rules={[
+                  { required: true, message: 'Please enter template name' },
+                  { max: 200, message: 'Name must be less than 200 characters' },
+                ]}
+              >
+                <Input placeholder="e.g., Summer Sale Template" />
+              </Form.Item>
+            </Col>
 
-          <Form.Item
-            name="description"
-            label="Description"
-            rules={[{ max: 500, message: 'Description must be less than 500 characters' }]}
-          >
-            <TextArea rows={3} placeholder="Brief description of this template" />
-          </Form.Item>
+            <Col xs={24}>
+              <Form.Item
+                name="description"
+                label="Description"
+                rules={[{ max: 500, message: 'Description must be less than 500 characters' }]}
+              >
+                <TextArea rows={3} placeholder="Brief description of this template" />
+              </Form.Item>
+            </Col>
 
-          <Form.Item
-            name="category_id"
-            label="Category"
-            rules={[{ required: true, message: 'Please select a category' }]}
-          >
-            <Select placeholder="Select a category">
-              {categories.map((category) => (
-                <Select.Option key={category.id} value={category.id}>
-                  {category.name}
-                </Select.Option>
-              ))}
-            </Select>
-          </Form.Item>
+            <Col xs={24} sm={24} md={12}>
+              <Form.Item
+                name="category_id"
+                label="Category"
+                rules={[{ required: true, message: 'Please select a category' }]}
+              >
+                <Select placeholder="Select a category">
+                  {categories.map((category) => (
+                    <Select.Option key={category.id} value={category.id}>
+                      {category.name}
+                    </Select.Option>
+                  ))}
+                </Select>
+              </Form.Item>
+            </Col>
 
-          <Form.Item name="is_featured" label="Is Featured" valuePropName="checked">
-            <Switch />
-          </Form.Item>
+            <Col xs={24} sm={12} md={6}>
+              <Form.Item name="is_featured" label="Is Featured" valuePropName="checked">
+                <Switch />
+              </Form.Item>
+            </Col>
 
-          <Form.Item name="display_order" label="Display Order">
-            <InputNumber min={0} style={{ width: '100%' }} />
-          </Form.Item>
+            <Col xs={24} sm={12} md={6}>
+              <Form.Item name="display_order" label="Display Order">
+                <InputNumber min={0} style={{ width: '100%' }} />
+              </Form.Item>
+            </Col>
 
-          <Form.Item>
-            <Space>
-              <Button onClick={onCancel} icon={<ArrowLeftCircle />}>
-                Cancel
-              </Button>
-              <Button type="primary" onClick={handleNextStep}>
-                Next: Design Template
-              </Button>
-            </Space>
-          </Form.Item>
+            <Col xs={24}>
+              <Form.Item>
+                <Space>
+                  <Button onClick={onCancel}>
+                    Cancel
+                  </Button>
+                  <Button type="primary" onClick={handleNextStep} loading={baseTemplateConfigCreation}>
+                    Next: Design Template
+                  </Button>
+                </Space>
+              </Form.Item>
+            </Col>
+          </Row>
         </Form>
       </Card>
-    </>
+    </div>
   );
 };
 

--- a/src/features/base-template/components/BaseTemplatesPage.tsx
+++ b/src/features/base-template/components/BaseTemplatesPage.tsx
@@ -8,6 +8,7 @@ import { useBaseTemplateActions, useBaseTemplateCategoriesListing } from '../hoo
 import { BaseProps } from '@/types/props';
 import { useBaseTemplateCategoriesListingStore } from '@/stores/list/baseTemplateCategoriesListing.store';
 import { useDebouncedCallback } from '@/lib/hooks';
+import { useSyncGenericContext } from '@/lib/hooks/use-sync-generic-context';
 import type { TableProps } from 'antd';
 import type { SorterResult } from 'antd/es/table/interface';
 import SharedTemplateTable from '@/components/common/shared-table';
@@ -20,23 +21,37 @@ interface BaseTemplatesPageProps extends Partial<BaseProps> {
 export const BaseTemplatesPage: React.FC<BaseTemplatesPageProps> = ({
   apiClient,
   navigate,
+  accountDetails,
+  authProvider,
+  shoppers,
+  accounts,
   onCreateTemplate,
 }) => {
+  useSyncGenericContext({
+    apiClient,
+    navigate,
+    accountDetails,
+    authProvider,
+    shoppers,
+    accounts,
+  });
+
   const { actions: categoryActions } = useCategoryStore();
   const {
     loading: actionsLoading,
     loadTemplates,
     createCategory,
     deleteTemplate,
+    updateTemplateStatus,
     editTemplate,
     previewTemplate,
-  } = useBaseTemplateActions({ apiClient });
+  } = useBaseTemplateActions();
 
   const {
     loading: categoriesLoading,
     getCategories,
     deleteCategory,
-  } = useBaseTemplateCategoriesListing({ apiClient });
+  } = useBaseTemplateCategoriesListing();
 
   const {
     categories: categoryRows,
@@ -189,6 +204,8 @@ export const BaseTemplatesPage: React.FC<BaseTemplatesPageProps> = ({
                 onEditTemplate={handleEditTemplate}
                 onPreviewTemplate={previewTemplate}
                 onDeleteTemplate={deleteTemplate}
+                onUpdateStatus={updateTemplateStatus}
+                onLoadTemplates={loadTemplates}
                 loading={actionsLoading}
                 navigate={navigate}
               />

--- a/src/features/base-template/hooks/useBaseTemplateCategoriesListing.ts
+++ b/src/features/base-template/hooks/useBaseTemplateCategoriesListing.ts
@@ -1,17 +1,14 @@
 import { useState } from 'react';
-import { AxiosInstance } from 'axios';
 import { message } from 'antd';
 import type { TablePaginationConfig } from 'antd';
 
 import { createAPI } from '@/api';
 import { useBaseTemplateCategoriesListingStore } from '@/stores/list/baseTemplateCategoriesListing.store';
 import { useCategoryStore } from '../stores';
+import { useGenericStore } from '@/stores/generic.store';
 
-export const useBaseTemplateCategoriesListing = ({
-  apiClient,
-}: {
-  apiClient?: AxiosInstance;
-}) => {
+export const useBaseTemplateCategoriesListing = () => {
+  const apiClient = useGenericStore((s) => s.apiClient);
   const [loading, setLoading] = useState(false);
 
   const { actions: categoryActions } = useCategoryStore();

--- a/src/features/base-template/types/index.ts
+++ b/src/features/base-template/types/index.ts
@@ -11,18 +11,41 @@ export interface Category {
 
 export interface BaseTemplate {
   id: string;
+  // Template identifiers and metadata from API
+  template_id: string;
+  template_name?: string;
+  template_description?: string | null;
+  // Normalized fields used across the app
   name: string;
   description: string | null;
   category_id: number | null;
   category?: Category;
   thumbnail_url: string | null;
-  design_json: any;
-  html_content: string | null;
+  builder_state_json: any;
   is_featured?: boolean;
   display_order?: number;
+  // Status fields (API may provide both status and template_status)
   status: 'draft' | 'active' | 'archived';
+  template_status?: string;
+  // Storage / infra metadata
+  s3_bucket?: string;
+  s3_key?: string;
+  s3_url?: string;
+  ip_address?: string | null;
+  user_agent?: string | null;
+  // Audit metadata
   created_at: string;
   updated_at: string;
+  created_by?: number;
+  updated_by?: number;
+  deleted_by?: number | null;
+  deleted_at?: string | null;
+  // Additional template meta
+  canvas_type?: string;
+  is_custom_coded?: boolean;
+  is_generic?: boolean;
+  remarks?: string | null;
+  child_templates?: BaseTemplate[] | null;
 }
 
 export interface BaseTemplateFilters {
@@ -47,7 +70,6 @@ export interface CreateBaseTemplateInput {
   description?: string;
   category_id?: number;
   design_json: any;
-  html_content?: string;
   thumbnail_url?: string;
 }
 

--- a/src/features/builder/components/BaseTemplateSelect.tsx
+++ b/src/features/builder/components/BaseTemplateSelect.tsx
@@ -1,0 +1,99 @@
+import React, { useMemo } from 'react';
+import { Select, Tag, Typography } from 'antd';
+import type { SelectProps } from 'antd';
+import { BaseTemplate } from '@/features/base-template/types';
+
+const { Text } = Typography;
+
+interface BaseTemplateSelectProps {
+  value?: string | null;
+  onChange?: (value: string | null) => void;
+  disabled?: boolean;
+  loading?: boolean;
+  baseTemplates: BaseTemplate[];
+}
+
+type BaseTemplateOption = {
+  value: string;
+  label: string;
+  searchLabel: string;
+  name: string;
+  categoryName: string;
+  isFeatured: boolean;
+};
+
+const BaseTemplateSelect: React.FC<BaseTemplateSelectProps> = ({
+  value,
+  onChange,
+  disabled,
+  loading,
+  baseTemplates,
+}) => {
+  const options: SelectProps['options'] = useMemo(() => {
+    const mapped: BaseTemplateOption[] = baseTemplates.map((t) => {
+      const categoryName = t.category?.name || 'Uncategorized';
+      const isFeatured = !!t.is_featured;
+      const name = t.name || t.template_id || 'Untitled template';
+      const collapsedLabel = categoryName ? `${name} — ${categoryName}` : name;
+
+      return {
+        value: t.template_id,
+        label: collapsedLabel,
+        searchLabel: `${name} ${categoryName}`.trim(),
+        name,
+        categoryName,
+        isFeatured,
+      };
+    });
+
+    return mapped;
+  }, [baseTemplates]);
+
+  const handleChange: SelectProps['onChange'] = (val) => {
+    if (onChange) {
+      onChange((val as string) ?? null);
+    }
+  };
+
+  return (
+    <Select
+      allowClear
+      showSearch
+      placeholder="Search base templates by name or category (leave empty to start from scratch)"
+      disabled={disabled}
+      loading={loading}
+      value={value ?? undefined}
+      onChange={handleChange}
+      options={options}
+      optionFilterProp="searchLabel"
+      optionRender={(option) => {
+        const data = option.data as BaseTemplateOption;
+        return (
+          <div className="flex flex-col">
+            <div className="flex items-center gap-2">
+              <Text strong ellipsis className="max-w-full">
+                {data.name}
+              </Text>
+              {data.isFeatured && (
+                <Tag color="gold" style={{ marginLeft: 4 }}>
+                  Featured
+                </Tag>
+              )}
+            </div>
+            <Text type="secondary" style={{ fontSize: 12 }} ellipsis>
+              {data.categoryName}
+            </Text>
+          </div>
+        );
+      }}
+      filterOption={(input, option) =>
+        ((option as any)?.searchLabel ?? '')
+          .toLowerCase()
+          .includes(input.toLowerCase())
+      }
+    />
+  );
+};
+
+export default BaseTemplateSelect;
+

--- a/src/features/builder/components/ReminderTabStep.tsx
+++ b/src/features/builder/components/ReminderTabStep.tsx
@@ -15,12 +15,12 @@ const ReminderTabStep: React.FC<ReminderTabStepProps> = ({
   onNext,
   onBack,
   onSave,
-  apiClient,
 }) => {
   const { reminderTabConfig, currentTemplateId, actions } = useBuilderStore();
   const { templateByIdLoading } = useLoadingStore();
+  const apiClient = useGenericStore((s) => s.apiClient);
 
-  // Initialize autosave
+  // Initialize autosave (apiClient from generic store)
   const {
     isSaving,
     lastSave,
@@ -32,7 +32,7 @@ const ReminderTabStep: React.FC<ReminderTabStepProps> = ({
     enabled: true,
     interval: 10000, // 10 seconds
     debounceDelay: 2000, // 2 seconds
-    apiClient: apiClient,
+    apiClient: apiClient ?? undefined,
     templateId: currentTemplateId || undefined,
     onSave: onSave,
     onError: (error) => {
@@ -43,7 +43,6 @@ const ReminderTabStep: React.FC<ReminderTabStepProps> = ({
 
   const handleConfigChange = useCallback(
     (config: any) => {
-      console.log('📝 ReminderTabStep: Config change detected', config);
       actions.setReminderTabConfig(config);
     },
     [actions]

--- a/src/features/builder/components/reminder-tab/ReminderTabEditor.tsx
+++ b/src/features/builder/components/reminder-tab/ReminderTabEditor.tsx
@@ -33,13 +33,11 @@ const ReminderTabEditor: React.FC<ReminderTabEditorProps> = ({
   // Determine supported devices from template
   const supportedDevices = useMemo(() => {
     if (!templateState?.devices) {
-      console.log('No devices found, defaulting to desktop');
       return ['desktop'];
     }
     const devices = templateState.devices.map((device) =>
       device.device_type.toLowerCase()
     );
-    console.log('Supported devices:', devices);
     return devices;
   }, [templateState?.devices]);
 
@@ -68,16 +66,16 @@ const ReminderTabEditor: React.FC<ReminderTabEditorProps> = ({
   React.useEffect(() => {
     if (!hasDesktop && hasMobile) {
       // Mobile-only template: ensure desktop is disabled, mobile is enabled
-      const newConfig = { 
-        ...config, 
+      const newConfig = {
+        ...config,
         desktop: { ...config.desktop, enabled: false },
         mobile: { ...config.mobile, enabled: true }
       };
       onConfigChange(newConfig);
     } else if (hasDesktop && !hasMobile) {
       // Desktop-only template: ensure mobile is disabled, desktop is enabled  
-      const newConfig = { 
-        ...config, 
+      const newConfig = {
+        ...config,
         desktop: { ...config.desktop, enabled: true },
         mobile: { ...config.mobile, enabled: false }
       };
@@ -108,7 +106,7 @@ const ReminderTabEditor: React.FC<ReminderTabEditorProps> = ({
         // Desktop-only template: disable mobile
         newConfig.mobile = { ...newConfig.mobile, enabled: false };
       }
-      
+
       onConfigChange(newConfig);
     },
     [config, onConfigChange, hasDesktop, hasMobile]
@@ -132,14 +130,7 @@ const ReminderTabEditor: React.FC<ReminderTabEditorProps> = ({
   }, []);
 
   // Memoized button handlers
-  const handleGeneratePreview = useCallback(() => {
-    console.log('Generated config:', config);
-  }, [config, convertToLegacyConfig]);
 
-  const handleViewCode = useCallback(() => {
-    console.log('Generated HTML code', config);
-    alert('Generated code logged to console!');
-  }, [config]);
 
   const handleResetColors = useCallback(() => {
     updateConfig('styling.colors.primary', '#8B0000');
@@ -153,12 +144,20 @@ const ReminderTabEditor: React.FC<ReminderTabEditorProps> = ({
     setPreviewDevice(e.target.value);
   }, []);
 
+  // When user switches left tab (Desktop Tab / Mobile Button), sync right preview to that device
+  const handleTabChange = useCallback((key: string) => {
+    setActiveTab(key);
+    if (key === 'desktop' || key === 'mobile') {
+      setPreviewDevice(key);
+    }
+  }, []);
+
   return (
     <Row gutter={[24, 24]}>
       {/* Configuration Panel */}
       <Col xs={24} lg={16}>
         <Card>
-          <Tabs activeKey={activeTab} onChange={setActiveTab}>
+          <Tabs activeKey={activeTab} onChange={handleTabChange}>
             {/* Desktop Configuration */}
             {hasDesktop && (
               <TabPane
@@ -268,18 +267,7 @@ const ReminderTabEditor: React.FC<ReminderTabEditorProps> = ({
         <Card className="mt-4">
           <Title level={5}>Quick Actions</Title>
           <Space direction="vertical" className="w-full">
-            <Button
-              type="primary"
-              icon={<EyeOutlined />}
-              block
-              onClick={handleGeneratePreview}
-            >
-              Generate Preview
-            </Button>
 
-            <Button icon={<CodeOutlined />} block onClick={handleViewCode}>
-              View Generated Code
-            </Button>
 
             <Button type="dashed" block onClick={handleResetColors}>
               Reset Colors

--- a/src/features/builder/hooks/index.ts
+++ b/src/features/builder/hooks/index.ts
@@ -10,3 +10,6 @@ export type { UseAutosaveOptions, UseAutosaveReturn } from './useAutosave';
 
 export { useUnlayerImageUpload } from './useUnlayerImageUpload';
 export type { UseUnlayerImageUploadOptions, UseUnlayerImageUploadReturn } from './useUnlayerImageUpload';
+
+export { useUnlayerDeviceOptions } from './useUnlayerDeviceOptions';
+export type { UnlayerDevice, UnlayerDeviceOptions } from './useUnlayerDeviceOptions';

--- a/src/features/builder/hooks/useAutosave.ts
+++ b/src/features/builder/hooks/useAutosave.ts
@@ -83,7 +83,6 @@ export const useAutosave = (
     }
 
     try {
-      console.log('🔄 Performing autosave...');
       
       const unlayer = editorRef.current.editor;
       
@@ -95,7 +94,6 @@ export const useAutosave = (
             ? processTemplateFields(design, templateFields)
             : design;
 
-            console.log(templateFields, design, processedDesign, templateFields.length > 0);
             
           
           // Only save to our custom API when enabled
@@ -105,7 +103,6 @@ export const useAutosave = (
             
             // Check if we're editing a template from client review
             if (selectedTemplate && selectedTemplate.template_id === templateId) {
-              console.log('💾 Auto-saving client review template via different API');
               
               // Use the client review template update API
               await api.templates.updateClientReviewTemplate(templateId, {
@@ -118,16 +115,12 @@ export const useAutosave = (
                 builder_state_json: processedDesign
               });
               
-              console.log('✅ Auto-saved client review template successfully');
             } else {
               if (saveMode === 'base') {
-                console.log('💾 Auto-saving basic template via basic update API');
                 await api.templates.updateBaseTemplate(templateId, {
                   builder_state_json: processedDesign,
                 });
-                console.log('✅ Auto-saved basic template successfully');
               } else {
-                console.log('💾 Auto-saving regular template via staging API');
                 
                 // Use regular staging template API
                 await api.templates.upsertTemplate(templateId, {
@@ -135,7 +128,6 @@ export const useAutosave = (
                   is_builder_state: true
                 });
                 
-                console.log('✅ Auto-saved regular template successfully');
               }
             }
             
@@ -144,7 +136,6 @@ export const useAutosave = (
             actions.markUnsavedChanges(false);
             actions.setLastAutoSave(new Date());
           } else {
-            console.log('⚠️ Auto-save skipped - API integration not enabled');
           }
           
           // Call external save handler if provided
@@ -152,7 +143,6 @@ export const useAutosave = (
             await onSave(processedDesign);
           }
           
-          console.log('✅ Autosave completed');
         } catch (error) {
           console.error('❌ Autosave error:', error);
           const err = error instanceof Error ? error : new Error('Autosave failed');
@@ -198,7 +188,6 @@ export const useAutosave = (
             
             // Check if we're editing a template from client review
             if (selectedTemplate && selectedTemplate.template_id === templateId) {
-              console.log('💾 Manual saving client review template via different API');
               
               // Use the client review template update API
               await api.templates.updateClientReviewTemplate(templateId, {
@@ -211,16 +200,12 @@ export const useAutosave = (
                 builder_state_json: processedDesign
               });
               
-              console.log('✅ Manual save client review template completed');
             } else {
               if (saveMode === 'base') {
-                console.log('💾 Manual saving basic template via basic update API');
                 await api.templates.updateBaseTemplate(templateId, {
                   builder_state_json: processedDesign,
                 });
-                console.log('✅ Manual save basic template completed');
               } else {
-                console.log('💾 Manual saving regular template via staging API');
                 
                 // Use regular staging template API
                 await api.templates.upsertTemplate(templateId, {
@@ -228,7 +213,6 @@ export const useAutosave = (
                   is_builder_state: true
                 });
                 
-                console.log('✅ Manual save regular template completed');
               }
             }
             
@@ -237,14 +221,12 @@ export const useAutosave = (
             actions.markUnsavedChanges(false);
             actions.setLastAutoSave(new Date());
           } else {
-            console.log('⚠️ Manual save skipped - API integration not enabled');
           }
           
           if (onSave) {
             await onSave(processedDesign);
           }
           
-          console.log('✅ Manual save completed');
           resolve();
         } catch (error) {
           console.error('❌ Manual save error:', error);
@@ -297,7 +279,6 @@ export const useAutosave = (
    * Manual auto-save trigger
    */
   const triggerAutoSave = useCallback(() => {
-    console.log('🎯 Manual auto-save triggered');
     performAutoSave();
   }, [performAutoSave]);
 
@@ -305,9 +286,7 @@ export const useAutosave = (
    * Force auto-save check (sets up interval if needed)
    */
   const forceAutoSaveCheck = useCallback(() => {
-    console.log('🔍 Force auto-save check triggered');
     if (autoSaveEnabled && hasUnsavedChanges && !intervalRef.current) {
-      console.log(`🕐 Setting up missing autosave interval: ${autoSaveInterval}ms`);
       
       intervalRef.current = setInterval(() => {
         performAutoSave();
@@ -329,15 +308,11 @@ export const useAutosave = (
 
     // Setup new interval if autosave is enabled and always keep it running
     if (autoSaveEnabled) {
-      console.log(`🕐 Setting up autosave interval: ${autoSaveInterval}ms (always active)`);
       
       intervalRef.current = setInterval(() => {
         // Only perform auto-save if there are unsaved changes
-        if (hasUnsavedChanges) {
-          console.log('🔄 Auto-save interval triggered with unsaved changes');
+        if (hasUnsavedChanges) {  
           performAutoSave();
-        } else {
-          console.log('⏭️ Auto-save interval skipped - no unsaved changes');
         }
       }, autoSaveInterval);
 

--- a/src/features/builder/hooks/useBaseTemplatesForConfig.ts
+++ b/src/features/builder/hooks/useBaseTemplatesForConfig.ts
@@ -1,0 +1,69 @@
+import { useState, useEffect } from 'react';
+import { createAPI } from '@/api';
+import { BaseTemplate } from '@/features/base-template/types';
+import { useGenericStore } from '@/stores/generic.store';
+
+interface UseBaseTemplatesForConfigReturn {
+  templates: BaseTemplate[];
+  loading: boolean;
+  loadTemplates: () => Promise<void>;
+}
+
+/**
+ * Hook to load base templates for selection in ConfigStep
+ * Returns active base templates sorted by display order
+ */
+export const useBaseTemplatesForConfig = (): UseBaseTemplatesForConfigReturn => {
+  const apiClient = useGenericStore((s) => s.apiClient);
+  const [templates, setTemplates] = useState<BaseTemplate[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const loadTemplates = async () => {
+    if (!apiClient) return;
+    setLoading(true);
+    try {
+      const api = createAPI(apiClient);
+      const response = await api.templates.getBaseTemplates({
+        limit: 100,
+        page: 1,
+        status: 'active',
+        sortColumn: 'bt.display_order',
+        sortDirection: 'ascend',
+      });
+      const results = response.results || [];
+
+      // Normalize API response shape into BaseTemplate model
+      const mapped: BaseTemplate[] = results.map((item: any) => ({
+        id: item.id,
+        template_id: item.template_id,
+        name: item.template_name,
+        description: item.template_description || null,
+        category_id: item.category_id || null,
+        category: item.category_id
+          ? {
+              id: item.category_id,
+              name: item.category_name,
+              description: null,
+              display_order: item.display_order ?? 0,
+            }
+          : undefined,
+        thumbnail_url: item.thumbnail_url || null,
+        builder_state_json: item.builder_state_json || {},
+        is_featured: item.is_featured || false,
+        display_order: item.display_order || 0,
+        status: item.status || 'active',
+        created_at: item.created_at || item.template_created_at,
+        updated_at: item.updated_at || item.template_updated_at || item.created_at,
+      }));
+
+      setTemplates(mapped);
+    } catch (error) {
+      console.error('Failed to load base templates:', error);
+      setTemplates([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { templates, loading, loadTemplates };
+};

--- a/src/features/builder/hooks/useBuilderMain.ts
+++ b/src/features/builder/hooks/useBuilderMain.ts
@@ -1,5 +1,4 @@
 import { message } from 'antd';
-import { AxiosInstance } from 'axios';
 import { createAPI } from '@/api';
 import { TCBTemplate, TCBTemplateStaging } from '@/types';
 import { useTemplateFieldsStore } from '@/stores/common/template-fields.store';
@@ -7,15 +6,21 @@ import { useBuilderStore } from '@/stores/builder.store';
 import { DEFAULT_REMINDER_TAB_CONFIG } from '../utils/reminderTabConstants';
 import { useLoadingStore } from '@/stores/common/loading.store';
 import { useBaseTemplateStore } from '@/features/base-template';
+import { useGenericStore } from '@/stores/generic.store';
 
-export const useBuilderMain = ({ apiClient }: { apiClient: AxiosInstance }) => {
-  const api = createAPI(apiClient);
+export const useBuilderMain = () => {
+  const apiClient = useGenericStore((s) => s.apiClient);
+  const api = apiClient ? createAPI(apiClient) : null;
 
   const { actions: templateFieldsActions } = useTemplateFieldsStore();
   const { actions: builderActions } = useBuilderStore();
   const { actions: loadingActions } = useLoadingStore();
 
   const getTemplateFields = async () => {
+    if (!api) {
+      message.error('API client is required');
+      throw new Error('API client is required');
+    }
     try {
       const response = await api.templateFields.getTemplateFields();
       templateFieldsActions.setTemplateFields(response);
@@ -28,6 +33,10 @@ export const useBuilderMain = ({ apiClient }: { apiClient: AxiosInstance }) => {
   };
 
   const createTemplate = async (data: any) => {
+    if (!api) {
+      message.error('API client is required');
+      throw new Error('API client is required');
+    }
     try {
       const response = await api.templates.createTemplate(data);
       return response;
@@ -39,6 +48,10 @@ export const useBuilderMain = ({ apiClient }: { apiClient: AxiosInstance }) => {
   };
 
   const updateTemplate = async (templateId: string, data: Partial<TCBTemplate>) => {
+    if (!api) {
+      message.error('API client is required');
+      throw new Error('API client is required');
+    }
     try {
       const response = await api.templates.updateTemplate(templateId, data);
       return response;
@@ -50,6 +63,10 @@ export const useBuilderMain = ({ apiClient }: { apiClient: AxiosInstance }) => {
   };
 
   const assignTemplateToShoppers = async (templateId: string, shopperId: number[]) => {
+    if (!api) {
+      message.error('API client is required');
+      throw new Error('API client is required');
+    }
     try {
       const response = await api.templates.assignTemplateToShoppers(templateId, shopperId);
       return response;
@@ -61,9 +78,12 @@ export const useBuilderMain = ({ apiClient }: { apiClient: AxiosInstance }) => {
   };
 
   const loadTemplate = async (templateId: string) => {
+    if (!api) {
+      message.error('API client is required');
+      throw new Error('API client is required');
+    }
     try {
       loadingActions.setTemplateByIdLoading(true);
-      console.log('🔄 Loading template:', templateId);
 
       // Get template data including staging data for reminder tab config
       const templateResponse = await api.templates.getTemplateById(templateId);
@@ -78,10 +98,8 @@ export const useBuilderMain = ({ apiClient }: { apiClient: AxiosInstance }) => {
             ...DEFAULT_REMINDER_TAB_CONFIG,
             ...templateResponse.reminder_tab_state_json,
           };
-          console.log('✅ Loaded existing reminder tab config from staging template');
         }
       } catch (stagingError) {
-        console.log('ℹ️ No staging template data found, using defaults');
       }
 
       // Update store with loaded data
@@ -92,7 +110,6 @@ export const useBuilderMain = ({ apiClient }: { apiClient: AxiosInstance }) => {
       builderActions.markReminderTabUnsaved(false);
       builderActions.setReminderTabLastSave(new Date());
 
-      console.log('✅ Template loaded successfully');
       return {
         template: templateResponse,
         reminderTabConfig,
@@ -107,6 +124,10 @@ export const useBuilderMain = ({ apiClient }: { apiClient: AxiosInstance }) => {
   };
 
   const loadBaseTemplate = async (templateId: string) => {
+    if (!api) {
+      message.error('API client is required');
+      throw new Error('API client is required');
+    }
     try {
       const templateActions = useBaseTemplateStore.getState().actions;
       const baseTemplate = await api.templates.getBaseTemplateById(templateId);
@@ -117,7 +138,6 @@ export const useBuilderMain = ({ apiClient }: { apiClient: AxiosInstance }) => {
       templateActions.setSelectedCategoryId(baseTemplate.category_id ?? null);
 
       useBuilderStore.getState().actions.setCurrentTemplateId(baseTemplate.template_id);
-      console.log(baseTemplate);
 
       templateActions.setDesignJson(baseTemplate.builder_state_json ?? null);
     } catch (error) {

--- a/src/features/builder/hooks/useReminderTabAutosave.ts
+++ b/src/features/builder/hooks/useReminderTabAutosave.ts
@@ -27,7 +27,6 @@ export interface UseReminderTabAutosaveReturn {
   saveError: string | null;
   performManualSave: () => Promise<void>;
   triggerAutoSave: () => void;
-  enableAutoSave: () => void;
   disableAutoSave: () => void;
 }
 
@@ -72,26 +71,12 @@ export const useReminderTabAutosave = (
   /**
    * Perform autosave operation
    */
-  const performAutoSave = useCallback(async () => {
-    console.log('🔄 performAutoSave called', {
-      autoSaveEnabled,
-      reminderTabUnsavedChanges,
-      reminderTabAutosaving,
-      templateId,
-      apiClient: !!apiClient
-    });
-    
+  const performAutoSave = useCallback(async () => {  
     if (!autoSaveEnabled || !reminderTabUnsavedChanges || reminderTabAutosaving) {
-      console.log('⏭️ Skipping autosave due to conditions:', {
-        autoSaveEnabled,
-        reminderTabUnsavedChanges,
-        reminderTabAutosaving
-      });
       return;
     }
 
     try {
-      console.log('🔄 Performing reminder tab autosave...');
       
       loadingActions.setReminderTabAutosaving(true);
       actions.setReminderTabSaveError(null);
@@ -104,7 +89,6 @@ export const useReminderTabAutosave = (
           is_builder_state: false
         });
         
-        console.log('✅ Reminder tab auto-saved to API');
       }
 
       // Call external save handler if provided
@@ -116,7 +100,6 @@ export const useReminderTabAutosave = (
       actions.markReminderTabUnsaved(false);
       actions.setReminderTabLastSave(new Date());
       
-      console.log('✅ Reminder tab autosave completed');
     } catch (error) {
       console.error('❌ Reminder tab autosave error:', error);
       const err = error instanceof Error ? error : new Error('Autosave failed');
@@ -147,7 +130,6 @@ export const useReminderTabAutosave = (
     }
 
     try {
-      console.log('🎯 Performing manual reminder tab save...');
       
       loadingActions.setReminderTabAutosaving(true);
       actions.setReminderTabSaveError(null);
@@ -166,7 +148,6 @@ export const useReminderTabAutosave = (
       actions.markReminderTabUnsaved(false);
       actions.setReminderTabLastSave(new Date());
       
-      console.log('✅ Manual reminder tab save completed');
     } catch (error) {
       console.error('❌ Manual reminder tab save error:', error);
       const err = error instanceof Error ? error : new Error('Manual save failed');
@@ -182,17 +163,14 @@ export const useReminderTabAutosave = (
    * Debounced autosave trigger
    */
   const triggerDebouncedAutoSave = useCallback(() => {
-    console.log(`⏰ Setting debounced autosave timer (${debounceDelay}ms)`);
     
     // Clear existing debounce timer
     if (debounceRef.current) {
       clearTimeout(debounceRef.current);
-      console.log('🚮 Cleared existing debounce timer');
     }
 
     // Set new debounce timer
     debounceRef.current = setTimeout(() => {
-      console.log('⏰ Debounce timer fired, performing autosave');
       performAutoSave();
     }, debounceDelay);
   }, [performAutoSave, debounceDelay]);
@@ -201,23 +179,13 @@ export const useReminderTabAutosave = (
    * Manual auto-save trigger (bypasses debounce)
    */
   const triggerAutoSave = useCallback(() => {
-    console.log('🎯 Manual auto-save trigger for reminder tab');
     performAutoSave();
   }, [performAutoSave]);
-
-  /**
-   * Enable autosave
-   */
-  const enableAutoSave = useCallback(() => {
-    console.log('✅ Reminder tab autosave enabled');
-    // This will be handled by the useEffect below
-  }, []);
 
   /**
    * Disable autosave
    */
   const disableAutoSave = useCallback(() => {
-    console.log('❌ Reminder tab autosave disabled');
     
     // Clear interval
     if (intervalRef.current) {
@@ -244,15 +212,11 @@ export const useReminderTabAutosave = (
 
     // Setup new interval if autosave is enabled
     if (autoSaveEnabled) {
-      console.log(`🕐 Setting up reminder tab autosave interval: ${propInterval}ms`);
       
       intervalRef.current = setInterval(() => {
         // Only perform auto-save if there are unsaved changes
         if (reminderTabUnsavedChanges && !reminderTabAutosaving) {
-          console.log('🔄 Reminder tab auto-save interval triggered with unsaved changes');
           performAutoSave();
-        } else {
-          console.log('⏭️ Reminder tab auto-save interval skipped - no unsaved changes or currently saving');
         }
       }, propInterval);
     }
@@ -272,7 +236,6 @@ export const useReminderTabAutosave = (
   useEffect(() => {
     // Skip on initial mount if lastConfigRef is not initialized properly
     if (lastConfigRef.current === null) {
-      console.log('🔄 Initial config setup, skipping change detection');
       lastConfigRef.current = JSON.parse(JSON.stringify(reminderTabConfig)); // Deep copy
       return;
     }
@@ -282,28 +245,13 @@ export const useReminderTabAutosave = (
     const currentConfigStr = JSON.stringify(reminderTabConfig);
     const configChanged = lastConfigStr !== currentConfigStr;
     
-    console.log('🔍 Config change check:', {
-      configChanged,
-      autoSaveEnabled,
-      templateId,
-      apiClient: !!apiClient,
-      lastConfigStr: lastConfigStr.substring(0, 100) + '...',
-      currentConfigStr: currentConfigStr.substring(0, 100) + '...',
-      lastConfig: lastConfigRef.current,
-      currentConfig: reminderTabConfig
-    });
-    
     if (configChanged) {
-      console.log('📝 Reminder tab config changed, marking as unsaved');
       actions.markReminderTabUnsaved(true);
       lastConfigRef.current = JSON.parse(JSON.stringify(reminderTabConfig)); // Deep copy to avoid reference issues
       
       // Trigger debounced autosave if enabled
       if (autoSaveEnabled) {
-        console.log('🔄 Triggering debounced autosave');
         triggerDebouncedAutoSave();
-      } else {
-        console.log('⚠️ Autosave not enabled', { autoSaveEnabled, templateId, apiClient: !!apiClient });
       }
     }
   }, [reminderTabConfig, actions, autoSaveEnabled, triggerDebouncedAutoSave, templateId, apiClient]);
@@ -313,7 +261,6 @@ export const useReminderTabAutosave = (
    */
   useEffect(() => {
     if (reminderTabUnsavedChanges && autoSaveEnabled && !reminderTabAutosaving) {
-      console.log('🚨 Unsaved changes detected, triggering debounced autosave');
       triggerDebouncedAutoSave();
     }
   }, [reminderTabUnsavedChanges, autoSaveEnabled, reminderTabAutosaving, triggerDebouncedAutoSave]);
@@ -334,7 +281,6 @@ export const useReminderTabAutosave = (
     saveError: reminderTabSaveError,
     performManualSave,
     triggerAutoSave,
-    enableAutoSave,
     disableAutoSave,
   };
 };

--- a/src/features/builder/hooks/useUnlayerDeviceOptions.ts
+++ b/src/features/builder/hooks/useUnlayerDeviceOptions.ts
@@ -1,0 +1,38 @@
+import { useMemo } from 'react';
+import { useBuilderStore } from '@/stores/builder.store';
+
+export type UnlayerDevice = 'desktop' | 'mobile';
+
+export interface UnlayerDeviceOptions {
+  devices: UnlayerDevice[];
+  defaultDevice: UnlayerDevice;
+}
+
+/**
+ * Derives Unlayer editor device options from template state.
+ * When template has only mobile → editor opens in mobile-only mode.
+ * When template has only desktop → editor opens in desktop-only mode.
+ * When both or no devices → editor shows both; default desktop.
+ * See https://docs.unlayer.com/builder/device-management
+ */
+export function useUnlayerDeviceOptions(): UnlayerDeviceOptions {
+  const templateState = useBuilderStore((s) => s.templateState);
+
+  return useMemo(() => {
+    const allowed: UnlayerDevice[] = ['desktop', 'mobile'];
+    if (!templateState?.devices?.length) {
+      return { devices: allowed, defaultDevice: 'desktop' };
+    }
+    const supported = templateState.devices
+      .map((d) => d.device_type.toLowerCase() as UnlayerDevice)
+      .filter((t): t is UnlayerDevice => allowed.includes(t));
+    const unique = [...new Set(supported)];
+    if (unique.length === 0) {
+      return { devices: allowed, defaultDevice: 'desktop' };
+    }
+    if (unique.length === 1) {
+      return { devices: unique, defaultDevice: unique[0] };
+    }
+    return { devices: ['desktop', 'mobile'], defaultDevice: 'desktop' };
+  }, [templateState?.devices]);
+}

--- a/src/features/builder/hooks/useUnlayerEditor.ts
+++ b/src/features/builder/hooks/useUnlayerEditor.ts
@@ -111,7 +111,6 @@ const decodeHtmlEntitiesInDesign = (designData: any): any => {
       if (key === 'text' && typeof value === 'string') {
         // Decode HTML entities in text fields
         processed[key] = decodeHtmlEntities(value);
-        console.log(`🔧 Decoded text: "${value}" → "${processed[key]}"`);
       } else if (typeof value === 'object') {
         // Recursively process nested objects
         processed[key] = processObject(value);
@@ -163,7 +162,6 @@ export const useUnlayerEditor = (options: UseUnlayerEditorOptions): UseUnlayerEd
         templateId,
         accountId,
         onUploadSuccess: (asset) => {
-          console.log('✅ Image uploaded via Unlayer:', asset);
         },
         onUploadError: (error) => {
           console.error('❌ Unlayer image upload failed:', error);
@@ -218,7 +216,6 @@ export const useUnlayerEditor = (options: UseUnlayerEditorOptions): UseUnlayerEd
         unlayer.loadDesign(design);
         actions.loadDesign(design);
 
-        console.log('✅ Design loaded successfully');
       } catch (error) {
         console.error('❌ Failed to load design:', error);
         const err = error instanceof Error ? error : new Error('Failed to load design');
@@ -246,16 +243,9 @@ export const useUnlayerEditor = (options: UseUnlayerEditorOptions): UseUnlayerEd
           saveMode === 'staging'
             ? useBuilderStore.getState().templateState
             : useBaseTemplateStore.getState().selectedTemplate;
-        console.log('🔍 Loading template - selectedTemplate:', selectedTemplateClient);
-        console.log('🔍 Loading template - templateId:', templateId);
 
         // Check if we're in template editing mode (from client review)
         if (selectedTemplateClient && selectedTemplateClient.template_id === templateId) {
-          console.log('📝 Loading template from client review selectedTemplate');
-          console.log(
-            '📝 Loading template from client review selectedTemplate:',
-            selectedTemplateClient
-          );
           // Use selectedTemplate data directly (it's already a ClientFlowData)
           if (selectedTemplateClient.builder_state_json) {
             let designData = selectedTemplateClient.builder_state_json;
@@ -263,7 +253,6 @@ export const useUnlayerEditor = (options: UseUnlayerEditorOptions): UseUnlayerEd
             if (typeof designData === 'string') {
               try {
                 designData = JSON.parse(designData);
-                console.log('✅ Parsed selectedTemplate JSON string to object');
               } catch (error) {
                 console.error(
                   '❌ Failed to parse selectedTemplate builder_state_json as JSON:',
@@ -281,9 +270,7 @@ export const useUnlayerEditor = (options: UseUnlayerEditorOptions): UseUnlayerEd
 
             if (designData && typeof designData === 'object') {
               if (!designData.body && !designData.counters) {
-                console.log("⚠️ selectedTemplate doesn't look like a valid Unlayer design format");
               } else {
-                console.log('🔧 Fixing HTML entity encoding in selectedTemplate design data...');
                 designData = decodeHtmlEntitiesInDesign(designData);
               }
             }
@@ -291,14 +278,11 @@ export const useUnlayerEditor = (options: UseUnlayerEditorOptions): UseUnlayerEd
             loadDesign(designData);
             onTemplateLoad?.(selectedTemplateClient);
           } else {
-            console.log('⚠️ selectedTemplate has no builder state');
             onTemplateLoad?.(selectedTemplateClient);
           }
         } else {
           // Normal template loading from API
-          console.log('📡 Loading template from API');
           const api = createAPI(apiClient);
-          console.log('this is selectedTemplateAdmin', !!selectedTemplateAdmin);
 
           const template = selectedTemplateAdmin?.id
             ? selectedTemplateAdmin
@@ -311,7 +295,6 @@ export const useUnlayerEditor = (options: UseUnlayerEditorOptions): UseUnlayerEd
             if (typeof designData === 'string') {
               try {
                 designData = JSON.parse(designData);
-                console.log('✅ Parsed API template JSON string to object');
               } catch (error) {
                 console.error('❌ Failed to parse API template builder_state_json as JSON:', error);
 
@@ -326,16 +309,13 @@ export const useUnlayerEditor = (options: UseUnlayerEditorOptions): UseUnlayerEd
 
             if (designData && typeof designData === 'object') {
               if (!designData.body && !designData.counters) {
-                console.log("⚠️ API template doesn't look like a valid Unlayer design format");
               } else {
-                console.log('🔧 Fixing HTML entity encoding in API template design data...');
                 designData = decodeHtmlEntitiesInDesign(designData);
               }
             }
             loadDesign(designData);
             onTemplateLoad?.(template);
           } else {
-            console.log('⚠️ API template has no builder state');
             onTemplateLoad?.(template);
           }
         }
@@ -373,7 +353,6 @@ export const useUnlayerEditor = (options: UseUnlayerEditorOptions): UseUnlayerEd
           actions.setCurrentDesign(design);
           actions.setExporting(false);
 
-          console.log('✅ HTML exported successfully');
           resolve(sanitizeHtml(html));
         } catch (error) {
           const err = error instanceof Error ? error : new Error('HTML export failed');
@@ -410,8 +389,6 @@ export const useUnlayerEditor = (options: UseUnlayerEditorOptions): UseUnlayerEd
           actions.setCurrentDesign(processedDesign);
           actions.setExporting(false);
 
-          console.log('✅ JSON exported successfully with template fields processed');
-          console.log('📋 Exported JSON:', processedDesign);
           resolve(processedDesign);
         } catch (error) {
           const err = error instanceof Error ? error : new Error('JSON export failed');
@@ -457,9 +434,6 @@ export const useUnlayerEditor = (options: UseUnlayerEditorOptions): UseUnlayerEd
       actions.exportBoth(design, html);
       actions.setExporting(false);
 
-      console.log('✅ Both HTML and JSON exported successfully with template fields processed');
-      console.log('📋 Exported JSON:', design);
-      console.log('🌐 Exported HTML:', html);
       return { design, html };
     } catch (error) {
       const err = error instanceof Error ? error : new Error('Export failed');
@@ -475,47 +449,30 @@ export const useUnlayerEditor = (options: UseUnlayerEditorOptions): UseUnlayerEd
    */
   const onEditorReady = useCallback(
     (unlayer: any) => {
-      console.log('🎉 Unlayer editor is ready');
 
       // Set project ID and ready state
       actions.setProjectId(projectId);
       actions.setReady(true);
 
       if (enableCustomImageUpload && apiClient && templateId && accountId) {
-        console.log('🚀 Configuring custom image upload with:', {
-          templateId,
-          accountId,
-          hasApiClient: !!apiClient,
-        });
         setupImageUpload(unlayer);
-        console.log('🖼️ Custom image upload configured for Unlayer');
       }
 
       // Load template if templateId provided and loading enabled
       if (loadTemplateOnReady && templateId && apiClient) {
-        console.log(`🚀 Auto-loading template ${templateId}...`);
         loadTemplateById(templateId);
       }
 
       // Set up comprehensive design change listeners for autosave
-      console.log('🔧 Setting up canvas change detection...');
 
       // Primary event: design:updated
       unlayer.addEventListener('design:updated', (updatedDesign: any) => {
-        console.log('🔄 design:updated event fired');
-        console.log('📊 Event data keys:', updatedDesign ? Object.keys(updatedDesign) : 'null');
-        console.log('⏰ Timestamp:', new Date().toISOString());
-        console.log('🎯 Current hasUnsavedChanges before:', store.hasUnsavedChanges);
-
         actions.setCurrentDesign(updatedDesign);
         actions.markUnsavedChanges(true);
         onDesignChange?.(updatedDesign);
 
         // Force auto-save check to ensure interval is running
-        console.log('🚀 Triggering auto-save check after design update');
-        forceAutoSaveCheck();
-
-        console.log('✅ Change state updated, hasUnsavedChanges now:', true);
+          forceAutoSaveCheck();
       });
 
       // Additional events to catch all possible changes
@@ -533,9 +490,6 @@ export const useUnlayerEditor = (options: UseUnlayerEditorOptions): UseUnlayerEd
         'content:updated',
       ];
 
-      // 🧪 ENHANCED DEBUG MODE - Test ALL possible events first
-      console.log('🔬 ENHANCED DEBUG MODE: Testing comprehensive event detection');
-
       // Test basic editor events first to see if ANY events work
       const basicTestEvents = [
         'ready',
@@ -551,48 +505,33 @@ export const useUnlayerEditor = (options: UseUnlayerEditorOptions): UseUnlayerEd
       basicTestEvents.forEach((eventName) => {
         try {
           unlayer.addEventListener(eventName, (eventData: any) => {
-            console.log(`🔥 BASIC EVENT FIRED: "${eventName}"`, {
-              hasData: !!eventData,
-              dataType: typeof eventData,
-              timestamp: new Date().toISOString(),
-            });
           });
         } catch (error) {
-          console.log(`❌ Failed to register basic event: ${eventName}`, error);
         }
       });
 
       additionalEvents.forEach((eventName) => {
         try {
           unlayer.addEventListener(eventName, (data: any) => {
-            console.log(`📡 Additional event fired: ${eventName}`, data ? 'with data' : 'no data');
-            console.log('⏰ Timestamp:', new Date().toISOString());
-
             // Mark as changed for any canvas operation
             if (!store.hasUnsavedChanges) {
-              console.log(`🔥 Marking unsaved changes from ${eventName} event`);
               actions.markUnsavedChanges(true);
             }
 
             // Force auto-save check for immediate response
-            console.log(`🚀 Triggering auto-save check from ${eventName} event`);
             forceAutoSaveCheck();
 
             // Optionally get current design and update store
             unlayer.saveDesign((currentDesign: any) => {
               actions.setCurrentDesign(currentDesign);
               onDesignChange?.(currentDesign);
-              console.log(`✅ Design updated from ${eventName} event`);
             });
           });
-          console.log(`✅ Registered event listener: ${eventName}`);
         } catch (error) {
-          console.log(`⚠️ Failed to register event listener: ${eventName}`, error);
         }
       });
 
       // Fallback: Periodic change detection
-      console.log('🔄 Setting up fallback change detection...');
       const changeDetectionInterval = setInterval(() => {
         if (!unlayer || !store.isReady) return;
 
@@ -601,14 +540,11 @@ export const useUnlayerEditor = (options: UseUnlayerEditorOptions): UseUnlayerEd
           const savedDesignStr = JSON.stringify(store.savedDesign);
 
           if (currentDesignStr !== savedDesignStr && !store.hasUnsavedChanges) {
-            console.log('🔍 Change detected via fallback polling');
-            console.log('⏰ Timestamp:', new Date().toISOString());
             actions.setCurrentDesign(currentDesign);
             actions.markUnsavedChanges(true);
             onDesignChange?.(currentDesign);
 
             // Force auto-save check for fallback detection
-            console.log('🚀 Triggering auto-save check from fallback detection');
             forceAutoSaveCheck();
           }
         });
@@ -616,14 +552,12 @@ export const useUnlayerEditor = (options: UseUnlayerEditorOptions): UseUnlayerEd
 
       // Cleanup interval on unmount/editor change
       const cleanup = () => {
-        console.log('🧹 Cleaning up change detection interval');
         clearInterval(changeDetectionInterval);
       };
 
       // Store cleanup function for later use
       (unlayer as any).__changeDetectionCleanup = cleanup;
 
-      console.log('✅ Unlayer editor initialized successfully');
     },
     [
       actions,

--- a/src/features/builder/hooks/useUnlayerImageUpload.ts
+++ b/src/features/builder/hooks/useUnlayerImageUpload.ts
@@ -87,20 +87,15 @@ export const useUnlayerImageUpload = (
       return;
     }
 
-    console.log('🔧 Setting up Unlayer image upload callbacks...');
     unlayerInstanceRef.current = unlayer;
 
     // Method 1: Override image upload callback
     unlayer.registerCallback('image', async (file: any, done: any) => {
       try {
-        console.log('🖼️ Unlayer image upload triggered:', file);
-        console.log('🔍 File structure:', JSON.stringify(file, null, 2));
         
         // Get the actual file from Unlayer's file object
         // According to Unlayer docs, file has attachments array
         const actualFile = file.attachments?.[0] || file;
-        
-        console.log('📁 Actual file:', actualFile);
         
         if (!actualFile) {
           console.error('❌ No file found in attachments');
@@ -129,8 +124,6 @@ export const useUnlayerImageUpload = (
         message.destroy();
         message.success('Image uploaded successfully');
         
-        console.log('✅ Image uploaded successfully:', imageUrl);
-        
       } catch (error) {
         console.error('❌ Image upload failed:', error);
         message.destroy();
@@ -147,7 +140,6 @@ export const useUnlayerImageUpload = (
     // Method 2: Override select image callback (for image gallery)
     unlayer.registerCallback('selectImage', async (data: any, done: any) => {
       try {
-        console.log('🖼️ Unlayer select image triggered:', data);
         
         // For now, we'll just open a simple file picker
         // This can be enhanced later with a custom image gallery modal
@@ -170,7 +162,6 @@ export const useUnlayerImageUpload = (
               message.destroy();
               message.success('Image selected and uploaded');
               
-              console.log('✅ Image selected and uploaded:', imageUrl);
             } catch (error) {
               message.destroy();
               message.error(`Upload failed: ${(error as Error).message}`);
@@ -188,21 +179,6 @@ export const useUnlayerImageUpload = (
       }
     });
 
-    // Log successful registration
-    console.log('✅ Image callback registered successfully');
-    console.log('✅ SelectImage callback registered successfully');
-    console.log('✅ Custom image upload handlers registered with Unlayer');
-    
-    // Test if the callback is accessible
-    setTimeout(() => {
-      console.log('🧪 Testing callback registration...');
-      if (typeof unlayer.registerCallback === 'function') {
-        console.log('✅ registerCallback function is available');
-      } else {
-        console.error('❌ registerCallback function not found on unlayer instance');
-      }
-    }, 1000);
-    
   }, [uploadImage]);
 
   return {

--- a/src/features/builder/types/reminderTab.d.ts
+++ b/src/features/builder/types/reminderTab.d.ts
@@ -115,12 +115,11 @@ export interface ReminderTabFileSizeEstimate {
   js: number;
 }
 
-// Props interfaces for components
+// Props interfaces for components (apiClient is read from generic store)
 export interface ReminderTabStepProps {
   onNext?: () => void;
   onBack?: () => void;
   onSave?: (config: ReminderTabConfig) => Promise<void>;
-  apiClient: AxiosInstance;
 }
 
 export interface ReminderTabSaveStatus {

--- a/src/features/builder/types/unlayer.d.ts
+++ b/src/features/builder/types/unlayer.d.ts
@@ -39,6 +39,19 @@ export interface UnlayerConfig {
   customCSS?: string;
   customJS?: string;
   fonts?: UnlayerFont[];
+  /** Restrict editor to desktop and/or mobile; see https://docs.unlayer.com/builder/device-management */
+  devices?: ('desktop' | 'mobile')[];
+  /** Initial device view when editor opens */
+  defaultDevice?: 'desktop' | 'mobile';
+  /** Tab visibility; see https://docs.unlayer.com/builder/latest/tab-management */
+  tabs?: {
+    content?: { enabled?: boolean };
+    blocks?: { enabled?: boolean };
+    popup?: { enabled?: boolean };
+    dev?: { enabled?: boolean };
+  };
+  /** Feature flags; e.g. audit tab via features.audit */
+  features?: { audit?: boolean };
 }
 
 // Appearance configuration

--- a/src/features/builder/utils/index.ts
+++ b/src/features/builder/utils/index.ts
@@ -16,6 +16,8 @@ export const manageEditorMode = (designMode: boolean = false): any => {
       text: { enabled: false },
       carousel: { enabled: false },
       html: { enabled: false },
+      table: { enabled: false },
+      paragraph: { enabled: false },
     };
   } else {
     return {

--- a/src/features/builder/utils/unlayerDefaultSelection.ts
+++ b/src/features/builder/utils/unlayerDefaultSelection.ts
@@ -1,0 +1,227 @@
+/**
+ * Tries to select the first block/content in the Unlayer editor so the property panel
+ * shows edit options by default (client edit mode). Uses Unlayer API if available,
+ * otherwise falls back to simulating a click on the first content element in the iframe.
+ */
+
+const EDITOR_CONTAINER_ID_CLIENT = 'bl-client-editor';
+
+/** Walk rows/columns|cells/contents and return the first content id found. */
+function getFirstContentIdFromSection(section: { rows?: any[] }): string | null {
+  const rows = section?.rows;
+  if (!Array.isArray(rows)) return null;
+  for (const row of rows) {
+    const cellsOrColumns = row.cells ?? row.columns;
+    if (!Array.isArray(cellsOrColumns)) continue;
+    for (const cell of cellsOrColumns) {
+      const contents = cell?.contents;
+      if (!Array.isArray(contents) || contents.length === 0) continue;
+      const id = contents[0]?.id;
+      if (id) return id;
+    }
+  }
+  return null;
+}
+
+/** Same for header/footer-style sections that have columns directly. */
+function getFirstContentIdFromColumns(section: { columns?: any[] }): string | null {
+  const columns = section?.columns;
+  if (!Array.isArray(columns)) return null;
+  for (const col of columns) {
+    const contents = col?.contents;
+    if (!Array.isArray(contents) || contents.length === 0) continue;
+    const id = contents[0]?.id;
+    if (id) return id;
+  }
+  return null;
+}
+
+/**
+ * Get the first selectable content id from Unlayer design JSON.
+ * Supports body.rows[].cells|columns[].contents[] and body.headers/footers[].columns[].contents[].
+ */
+function getFirstContentId(design: any): string | null {
+  if (!design?.body) return null;
+  const body = design.body;
+  const fromRows = getFirstContentIdFromSection(body);
+  if (fromRows) return fromRows;
+  const headers = body.headers;
+  if (Array.isArray(headers)) {
+    for (const h of headers) {
+      const id = getFirstContentIdFromColumns(h);
+      if (id) return id;
+    }
+  }
+  const footers = body.footers;
+  if (Array.isArray(footers)) {
+    for (const f of footers) {
+      const id = getFirstContentIdFromColumns(f);
+      if (id) return id;
+    }
+  }
+  return null;
+}
+
+/** Try common Unlayer-style select API names. */
+const SELECT_API_NAMES = [
+  'selectBlock',
+  'selectContent',
+  'setSelected',
+  'selectElement',
+  'setSelectedBlock',
+  'selectById',
+  'selectContentBlock',
+];
+
+/**
+ * Try to select the first content block via Unlayer API (if exposed).
+ */
+function trySelectViaApi(unlayer: any, contentId: string): boolean {
+  for (const name of SELECT_API_NAMES) {
+    const fn = unlayer[name];
+    if (typeof fn !== 'function') continue;
+    try {
+      fn.call(unlayer, contentId);
+      return true;
+    } catch {
+      // try next
+    }
+  }
+  return false;
+}
+
+/**
+ * Fallback: simulate click on first content in the editor iframe so the property panel opens.
+ * If contentId is provided, tries to find an element with that id (data-id, data-block-id, etc.) first.
+ */
+function tryClickFirstContentInEditor(editorId: string, contentId?: string | null): void {
+  try {
+    const container = document.getElementById(editorId);
+    if (!container) return;
+    const iframe = container.querySelector('iframe');
+    if (!iframe?.contentDocument) return;
+    const doc = iframe.contentDocument;
+
+    const clickEl = (el: Element) => {
+      if (el instanceof HTMLElement) {
+        el.dispatchEvent(new MouseEvent('click', { bubbles: true, view: doc.defaultView ?? window }));
+      }
+    };
+
+    if (contentId) {
+      const byIdSelectors = [
+        `[data-id="${contentId}"]`,
+        `[data-block-id="${contentId}"]`,
+        `[data-content-id="${contentId}"]`,
+        `[id="${contentId}"]`,
+      ];
+      for (const sel of byIdSelectors) {
+        const el = doc.querySelector(sel);
+        if (el) {
+          clickEl(el);
+          return;
+        }
+      }
+      const byIdContains = doc.querySelectorAll('[data-id], [data-block-id], [data-content-id]');
+      for (const el of byIdContains) {
+        const id = el.getAttribute('data-id') ?? el.getAttribute('data-block-id') ?? el.getAttribute('data-content-id');
+        if (id === contentId) {
+          clickEl(el);
+          return;
+        }
+      }
+    }
+
+    const selectors = [
+      '[data-block-id]',
+      '[data-id]',
+      '.unlayer-block',
+      '[data-type="image"]',
+      '[data-type="text"]',
+      '[class*="content-block"]',
+      '[class*="block-wrapper"]',
+      '.unlayer-edit-mode [class*="content"]',
+      '[class*="row"] [class*="cell"]',
+      '[class*="row"] [class*="column"]',
+      'div[contenteditable="true"]',
+    ];
+    for (const sel of selectors) {
+      const el = doc.querySelector(sel);
+      if (el && el instanceof HTMLElement) {
+        clickEl(el);
+        return;
+      }
+    }
+    const canvas = doc.querySelector('[class*="canvas"]') ?? doc.body;
+    const firstBlock = canvas?.querySelector('[class*="block"], [class*="content"], [class*="row"] div');
+    if (firstBlock) clickEl(firstBlock);
+  } catch {
+    // avoid breaking the editor
+  }
+}
+
+/**
+ * Registers a one-time design:loaded listener and tries to select the first block
+ * so the left property panel shows edit options. Call from onEditorReady in client edit flow.
+ * Retries at longer intervals so selection runs after async template load (loadTemplateById).
+ */
+export function selectFirstBlockWhenReady(unlayer: any, editorId: string = EDITOR_CONTAINER_ID_CLIENT): void {
+  let didSelect = false;
+
+  const run = () => {
+    if (didSelect) return;
+    try {
+      unlayer.saveDesign((design: any) => {
+        if (didSelect) return;
+        const hasBody = design?.body?.rows?.length > 0 || design?.body?.columns?.length > 0;
+        if (!hasBody && !design?.body?.headers?.length && !design?.body?.footers?.length) return;
+        const firstId = getFirstContentId(design);
+        if (firstId && trySelectViaApi(unlayer, firstId)) {
+          didSelect = true;
+          return;
+        }
+        tryClickFirstContentInEditor(editorId, firstId ?? undefined);
+        didSelect = true;
+      });
+    } catch {
+      // ignore
+    }
+  };
+
+  try {
+    unlayer.addEventListener('design:loaded', () => {
+      setTimeout(run, 150);
+      setTimeout(run, 500);
+    });
+    // Retry at intervals so we catch when design is ready (template loads async after onReady)
+    [600, 1200, 2000, 3200, 4800, 6500].forEach((ms) => setTimeout(run, ms));
+  } catch {
+    // avoid breaking the editor
+  }
+}
+
+/**
+ * Hide the Popup tab in the editor sidebar (fallback when tabs.popup.enabled: false is ignored).
+ * Call after editor is ready. Looks for tab-like elements with "Popup" text in the editor iframe.
+ */
+export function hidePopupTabInEditor(editorId: string = EDITOR_CONTAINER_ID_CLIENT): void {
+  const hide = () => {
+    try {
+      const container = document.getElementById(editorId);
+      const iframe = container?.querySelector('iframe');
+      const doc = iframe?.contentDocument;
+      if (!doc) return;
+      const all = doc.querySelectorAll('[role="tab"], [class*="tab"], [data-tab]');
+      all.forEach((el) => {
+        if (el.textContent?.trim().toLowerCase() === 'popup') {
+          (el as HTMLElement).style.setProperty('display', 'none', 'important');
+        }
+      });
+    } catch {
+      // ignore
+    }
+  };
+  hide();
+  setTimeout(hide, 500);
+  setTimeout(hide, 1500);
+}

--- a/src/features/canned-content/components/content-list.tsx
+++ b/src/features/canned-content/components/content-list.tsx
@@ -23,6 +23,7 @@ import SharedTemplateTable, {
 import { useLoadingStore } from '@/stores/common/loading.store';
 import CannedContentForm from './content-form';
 import { useGenericStore } from '@/stores/generic.store';
+import { useSyncGenericContext } from '@/lib/hooks/use-sync-generic-context';
 import { splitByAndCapitalize } from '@/lib/utils/helper';
 
 const { Search } = Input;
@@ -35,7 +36,17 @@ const CannedContentList: React.FC<CannedContentListProps> = ({
   shoppers,
   accountDetails,
   authProvider,
+  accounts,
 }) => {
+  useSyncGenericContext({
+    apiClient,
+    navigate,
+    accountDetails,
+    authProvider,
+    shoppers,
+    accounts,
+  });
+
   const [isFormVisible, setIsFormVisible] = useState(false);
   const [editingContent, setEditingContent] = useState<CBCannedContent | null>(
     null
@@ -46,13 +57,11 @@ const CannedContentList: React.FC<CannedContentListProps> = ({
 
   const { contentSubDataLoading, contentListingLoading } = useLoadingStore();
 
-  const {
-    actions: genericActions,
-    accountDetails: genericAccountDetails,
-    shoppers: genericShoppers,
-    authProvider: genericAuthProvider,
-    navigate: genericNavigate,
-  } = useGenericStore();
+  const genericActions = useGenericStore((s) => s.actions);
+  const genericAccountDetails = useGenericStore((s) => s.accountDetails);
+  const genericShoppers = useGenericStore((s) => s.shoppers);
+  const genericAuthProvider = useGenericStore((s) => s.authProvider);
+  const genericNavigate = useGenericStore((s) => s.navigate);
 
   const {
     getContent,
@@ -61,7 +70,7 @@ const CannedContentList: React.FC<CannedContentListProps> = ({
     createContent,
     getFields,
     getIndustries,
-  } = useContent({ apiClient });
+  } = useContent();
 
   const handleTableChange: TableProps<CBCannedContent>['onChange'] = (
     newPagination,

--- a/src/features/canned-content/hooks/use-content.ts
+++ b/src/features/canned-content/hooks/use-content.ts
@@ -2,15 +2,17 @@ import { createAPI } from '@/api';
 import { useLoadingStore } from '@/stores/common/loading.store';
 import { useContentListingStore } from '@/stores/list/contentListing';
 import { message } from 'antd';
-import { AxiosInstance } from 'axios';
+import { useGenericStore } from '@/stores/generic.store';
 
-export const useContent = ({ apiClient }: { apiClient: AxiosInstance }) => {
-  const api = createAPI(apiClient);
+export const useContent = () => {
+  const apiClient = useGenericStore((s) => s.apiClient);
+  const api = apiClient ? createAPI(apiClient) : null;
 
   const { actions: loadingActions } = useLoadingStore();
   const { actions } = useContentListingStore();
 
   const getContent = async () => {
+    if (!api) return;
     loadingActions.setContentListingLoading(true);
     try {
       const response = await api.content.getContent();
@@ -29,6 +31,7 @@ export const useContent = ({ apiClient }: { apiClient: AxiosInstance }) => {
   };
 
   const getContentById = async (id: number) => {
+    if (!api) return;
     loadingActions.setContentListingLoading(true);
     try {
       const response = await api.content.getContentById(id);
@@ -48,6 +51,7 @@ export const useContent = ({ apiClient }: { apiClient: AxiosInstance }) => {
     remarks?: string;
     shopper_id: number;
   }) => {
+    if (!api) return;
     loadingActions.setContentActionLoading(true);
     try {
       const response = await api.content.createContent(data);
@@ -67,6 +71,7 @@ export const useContent = ({ apiClient }: { apiClient: AxiosInstance }) => {
     remarks?: string;
     shopper_id?: number;
   }) => {
+    if (!api) return;
     loadingActions.setContentActionLoading(true);
     try {
       const response = await api.content.updateContent(id, data);
@@ -80,6 +85,7 @@ export const useContent = ({ apiClient }: { apiClient: AxiosInstance }) => {
   };
 
   const deleteContent = async (id: number) => {
+    if (!api) return;
     loadingActions.setContentActionLoading(true);
     try {
       await api.content.deleteContent(id);
@@ -93,6 +99,7 @@ export const useContent = ({ apiClient }: { apiClient: AxiosInstance }) => {
   };
 
   const getIndustries = async () => {
+    if (!api) return;
     loadingActions.setContentSubDataLoading(true);
     try {
       const response = await api.content.getIndustries();
@@ -106,6 +113,7 @@ export const useContent = ({ apiClient }: { apiClient: AxiosInstance }) => {
   };
 
   const getFields = async () => {
+    if (!api) return;
     loadingActions.setContentSubDataLoading(true);
     try {
       const response = await api.templateFields.getTemplateFields();

--- a/src/features/client-flow/components/ClientEditorStep.tsx
+++ b/src/features/client-flow/components/ClientEditorStep.tsx
@@ -1,35 +1,57 @@
 import React, { useEffect } from 'react';
-import { message, Alert, Button, Card, Row, Col, Space, Typography, Badge } from 'antd';
-import { ArrowRightOutlined, SaveOutlined } from '@ant-design/icons';
+import { message, Alert, Button, Card, Row, Col, Space, Typography, Badge, Spin, Popover, Modal } from 'antd';
+import { ArrowRightOutlined, SaveOutlined, InfoCircleOutlined, LogoutOutlined } from '@ant-design/icons';
 import EmailEditor, { UnlayerOptions } from 'react-email-editor';
 import { useBuilderStore } from '@/stores/builder.store';
 import { useGenericStore } from '@/stores/generic.store';
 import { useLoadingStore } from '@/stores/common/loading.store';
 import { useUnlayerEditor } from '../../builder/hooks/useUnlayerEditor';
+import { useUnlayerDeviceOptions } from '../../builder/hooks/useUnlayerDeviceOptions';
 import { manageEditorMode, manageMergeTags } from '../../builder/utils';
+import { selectFirstBlockWhenReady, hidePopupTabInEditor } from '../../builder/utils/unlayerDefaultSelection';
 
 const { Title, Text } = Typography;
 
+const EDIT_INFO_POINTS = [
+  'Click on template items below to edit their properties (text, images, colors, etc.) in the left panel.',
+  'You don\'t have to continue to the next step if you\'re done with your design.',
+];
+
+const editInfoPopoverContent = (
+  <div style={{ maxWidth: 320 }}>
+    <Text strong style={{ display: 'block', marginBottom: 8 }}>Editing tips</Text>
+    <ul style={{ margin: 0, paddingLeft: 18, lineHeight: 1.6 }}>
+      {EDIT_INFO_POINTS.map((point, i) => (
+        <li key={i} style={{ marginBottom: 4 }}>
+          <Text type="secondary">{point}</Text>
+        </li>
+      ))}
+    </ul>
+  </div>
+);
+
 export interface ClientEditorStepProps {
   unlayerConfig: UnlayerOptions;
-  apiClient: any;
   templateId: string;
   onNext: () => void;
+  onExit?: () => void;
 }
 
 /**
  * ClientEditorStep - Editor step for client flow
- * Simplified version of UnlayerMain without admin navigation
+ * Simplified version of UnlayerMain without admin navigation (apiClient from generic store)
  */
 export const ClientEditorStep: React.FC<ClientEditorStepProps> = ({
   unlayerConfig,
-  apiClient,
   templateId,
   onNext,
+  onExit,
 }) => {
-  const { currentTemplateId } = useBuilderStore();
-  const { authProvider } = useGenericStore();
+  const { currentTemplateId, templateState } = useBuilderStore();
+  const authProvider = useGenericStore((s) => s.authProvider);
+  const apiClient = useGenericStore((s) => s.apiClient);
   const { builderAutosaving } = useLoadingStore();
+  const { devices, defaultDevice } = useUnlayerDeviceOptions();
 
   const {
     editorRef,
@@ -77,12 +99,22 @@ export const ClientEditorStep: React.FC<ClientEditorStepProps> = ({
     }
   };
 
+  const handleExitClick = () => {
+    Modal.confirm({
+      title: 'Exit editor?',
+      content: 'Have you saved your changes? If you are done with your design, you can exit and return to the review step.',
+      okText: 'Yes, exit',
+      cancelText: 'Stay',
+      onOk: () => onExit?.(),
+    });
+  };
+
   return (
     <div style={{ padding: '16px' }}>
       {/* Header Controls */}
       <Card style={{ marginBottom: '16px' }}>
         <Row gutter={16} align="middle">
-          <Col>
+          <Col xs={24} sm={12}>
             <Title level={4} style={{ margin: 0 }}>
               Edit Popup Design
               {hasUnsavedChanges && (
@@ -93,9 +125,7 @@ export const ClientEditorStep: React.FC<ClientEditorStepProps> = ({
                 />
               )}
             </Title>
-          </Col>
-          <Col flex="auto">
-            <Space>
+            <div>
               <Text type="secondary">
                 Status: {isReady ? 'Ready' : 'Loading...'}
               </Text>
@@ -104,18 +134,30 @@ export const ClientEditorStep: React.FC<ClientEditorStepProps> = ({
                   Last saved: {lastAutoSave.toLocaleTimeString()}
                 </Text>
               )}
-            </Space>
+            </div>
           </Col>
-          <Col>
-            <Button
-              type="primary"
-              icon={<SaveOutlined />}
-              onClick={handleManualSave}
-              loading={isSaving || builderAutosaving}
-              disabled={!isReady || !hasUnsavedChanges}
-            >
-              {isSaving || builderAutosaving ? 'Saving...' : 'Save'}
-            </Button>
+
+          <Col xs={24} md={12} className='text-right'>
+            <Space>
+              <Popover
+                content={editInfoPopoverContent}
+                title={null}
+                trigger="hover"
+                placement="bottomRight"
+                styles={{ body: { padding: '12px 16px' } }}
+              >
+                <Button type='text' aria-label="Editing tips" icon={<InfoCircleOutlined className='text-blue-500' />} />
+              </Popover>
+              <Button
+                type="primary"
+                icon={<SaveOutlined />}
+                onClick={handleManualSave}
+                loading={isSaving || builderAutosaving}
+                disabled={!isReady || !hasUnsavedChanges}
+              >
+                {isSaving || builderAutosaving ? 'Saving...' : 'Save'}
+              </Button>
+            </Space>
           </Col>
         </Row>
       </Card>
@@ -132,7 +174,7 @@ export const ClientEditorStep: React.FC<ClientEditorStepProps> = ({
         />
       )}
 
-      {/* Editor Container */}
+      {/* Editor Container - only mount when template (and devices) is loaded so device view is correct */}
       <Card>
         <div
           style={{
@@ -142,25 +184,65 @@ export const ClientEditorStep: React.FC<ClientEditorStepProps> = ({
             overflow: 'hidden',
           }}
         >
-          <EmailEditor
-            editorId="bl-client-editor"
-            ref={editorRef}
-            onReady={onEditorReady}
-            options={{
-              ...unlayerConfig,
-              tools: manageEditorMode(true), // Always design mode for client
-              mergeTags: manageMergeTags(),
-            }}
-            style={{
-              height: '700px',
-              width: '100%',
-            }}
-          />
+          {!templateState ? (
+            <div className="flex items-center justify-center h-full min-h-[400px]">
+              <Spin size="large" tip="Loading editor..." />
+            </div>
+          ) : (
+            <EmailEditor
+              key={`bl-client-editor-${templateId ?? ''}-${devices.join('-')}-${defaultDevice}`}
+              editorId="bl-client-editor"
+              ref={editorRef}
+              onReady={(unlayer) => {
+                onEditorReady(unlayer);
+                selectFirstBlockWhenReady(unlayer, 'bl-client-editor');
+                hidePopupTabInEditor('bl-client-editor');
+              }}
+              options={{
+                ...unlayerConfig,
+                appearance: {
+                  ...unlayerConfig.appearance,
+                  panels: {
+                    ...unlayerConfig.appearance?.panels,
+                    tools: {
+                      ...unlayerConfig.appearance?.panels?.tools,
+                      dock: 'left',
+                    },
+                  },
+                },
+                tools: manageEditorMode(true), // Always design mode for client
+                mergeTags: manageMergeTags(),
+                devices,
+                defaultDevice,
+                tabs: {
+                  content: { enabled: false },
+                  blocks: { enabled: false },
+                  popup: { enabled: false },
+                  Popup: { enabled: false },
+                  dev: { enabled: false },
+                },
+                features: { audit: false },
+              }}
+              style={{
+                height: '700px',
+                width: '100%',
+              }}
+            />
+          )}
         </div>
       </Card>
 
       {/* Navigation */}
-      <div className="flex justify-end mt-6">
+      <div className="flex justify-end gap-2 mt-6">
+        {onExit && (
+          <Button
+            size="large"
+            icon={<LogoutOutlined />}
+            onClick={handleExitClick}
+          >
+            Exit
+          </Button>
+        )}
         <Button
           type="primary"
           size="large"

--- a/src/features/client-flow/components/ClientReminderTabStep.tsx
+++ b/src/features/client-flow/components/ClientReminderTabStep.tsx
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react';
 import { message, Alert, Spin, Button, Card, Space, Typography } from 'antd';
 import { ArrowLeftOutlined, SaveOutlined, LoadingOutlined } from '@ant-design/icons';
 import { useBuilderStore } from '@/stores/builder.store';
+import { useGenericStore } from '@/stores/generic.store';
 import { useLoadingStore } from '@/stores/common/loading.store';
 import { ReminderTabEditor } from '../../builder/components/reminder-tab';
 import { useReminderTabAutosave } from '../../builder/hooks/useReminderTabAutosave';
@@ -9,20 +10,19 @@ import { useReminderTabAutosave } from '../../builder/hooks/useReminderTabAutosa
 const { Title, Text } = Typography;
 
 export interface ClientReminderTabStepProps {
-  apiClient: any;
   onBack: () => void;
   onComplete?: () => void;
 }
 
 /**
  * ClientReminderTabStep - Reminder tab step for client flow
- * Simplified version with client-specific navigation
+ * Simplified version with client-specific navigation (apiClient from generic store)
  */
 export const ClientReminderTabStep: React.FC<ClientReminderTabStepProps> = ({
-  apiClient,
   onBack,
   onComplete,
 }) => {
+  const apiClient = useGenericStore((s) => s.apiClient);
   const { reminderTabConfig, currentTemplateId, actions } = useBuilderStore();
   const { templateByIdLoading } = useLoadingStore();
 
@@ -36,7 +36,7 @@ export const ClientReminderTabStep: React.FC<ClientReminderTabStepProps> = ({
     enabled: true,
     interval: 10000,
     debounceDelay: 2000,
-    apiClient: apiClient,
+    apiClient: apiClient ?? undefined,
     templateId: currentTemplateId || undefined,
     onError: (error) => {
       console.error('Reminder tab autosave error:', error);

--- a/src/features/client-flow/components/content-form.tsx
+++ b/src/features/client-flow/components/content-form.tsx
@@ -58,7 +58,6 @@ const ContentForm = () => {
   const handleSubmit = async (values: ContentFormData) => {
     setIsLoading(true);
     try {
-      console.log('Form submitted with values:', values);
       message.success('Content saved successfully!');
     } catch (error) {
       console.error('Error saving content:', error);

--- a/src/features/client-flow/components/feedback-form.tsx
+++ b/src/features/client-flow/components/feedback-form.tsx
@@ -42,7 +42,6 @@ const FeedbackForm: React.FC<FeedbackFormProps> = ({ type }) => {
   };
 
   const handleSubmit = (values: any) => {
-    console.log('Form submitted with values:', values);
     // Handle form submission logic here
   };
 

--- a/src/features/client-flow/components/shopper-details.tsx
+++ b/src/features/client-flow/components/shopper-details.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useClientFlow } from '../hooks/use-client-flow';
 import { useGenericStore } from '@/stores/generic.store';
-import { AxiosInstance } from 'axios';
 import { useClientFlowStore } from '@/stores/clientFlowStore';
 import { useLoadingStore } from '@/stores/common/loading.store';
 import { Card, Typography, Button, Modal, Carousel, Image, Divider, Tabs, Tooltip, Collapse } from 'antd';
@@ -13,13 +12,12 @@ import { Users, AlertCircle, CheckCircle, Eye, FileText, Activity, Lightbulb } f
 const { Text, Title, Paragraph } = Typography;
 
 interface ShopperDetailsProps {
-  apiClient: AxiosInstance;
   compact?: boolean;
   displayMode?: 'compact' | 'full' | 'legacy';
 }
 
-const ShopperDetails: React.FC<ShopperDetailsProps> = ({ apiClient, compact = false, displayMode }) => {
-  const { getShopperDetails } = useClientFlow({ apiClient });
+const ShopperDetails: React.FC<ShopperDetailsProps> = ({ compact = false, displayMode }) => {
+  const { getShopperDetails } = useClientFlow();
 
   const { activeContentShopper, shopperDetails } = useClientFlowStore();
   const { shopperDetailsLoading } = useLoadingStore();

--- a/src/features/client-flow/components/shopper-segment-selector.tsx
+++ b/src/features/client-flow/components/shopper-segment-selector.tsx
@@ -49,8 +49,6 @@ const ShopperSegmentSelector: React.FC<ShopperSegmentSelectorProps> = ({ compact
         mainShopperIds.has(shopper.id)
       );
 
-      console.log(result, uniqueTemplateShoppers, clientData, '==========================================');
-
 
       setTemplateShopperGroups(result);
       setDefaultShopper({ label: result[0].name, value: result[0].id });

--- a/src/features/client-flow/hooks/use-client-flow.ts
+++ b/src/features/client-flow/hooks/use-client-flow.ts
@@ -4,10 +4,10 @@ import { useDevicesStore } from '@/stores/common/devices.store';
 import { useLoadingStore } from '@/stores/common/loading.store';
 import { useGenericStore } from '@/stores/generic.store';
 import { message } from 'antd';
-import { AxiosInstance } from 'axios';
 
-export const useClientFlow = ({ apiClient }: { apiClient: AxiosInstance }) => {
-  const api = createAPI(apiClient);
+export const useClientFlow = () => {
+  const apiClient = useGenericStore((s) => s.apiClient);
+  const api = apiClient ? createAPI(apiClient) : null;
   const { actions: loadingActions } = useLoadingStore();
   const { actions: clientFlowActions, clientData } = useClientFlowStore();
   const { devices, actions: deviceActions } = useDevicesStore();
@@ -23,6 +23,7 @@ export const useClientFlow = ({ apiClient }: { apiClient: AxiosInstance }) => {
     shopper_id: number;
     shopper_name: string;
   }) => {
+    if (!api) return;
     loadingActions.setShopperDetailsLoading(true);
     try {
       const response = await api.content.getShopperDetails({
@@ -51,6 +52,7 @@ export const useClientFlow = ({ apiClient }: { apiClient: AxiosInstance }) => {
   };
 
   const getCleintTemplatesData = async (accountId: number) => {
+    if (!api) return;
     if (clientData && clientData.length) {
       return;
     }
@@ -68,6 +70,7 @@ export const useClientFlow = ({ apiClient }: { apiClient: AxiosInstance }) => {
   };
 
   const getContentFieldsWithContent = async (accountId: number) => {
+    if (!api) return;
     loadingActions.setContentSubDataLoading(true);
     try {
       const response =
@@ -82,6 +85,7 @@ export const useClientFlow = ({ apiClient }: { apiClient: AxiosInstance }) => {
   };
 
   const getDevices = async () => {
+    if (!api) return;
     if (devices.length > 0) return;
 
     loadingActions.setDevicesLoading(true);

--- a/src/features/client-flow/index.ts
+++ b/src/features/client-flow/index.ts
@@ -23,7 +23,7 @@ export type { ClientEditorProps } from './screens/ClientEditor';
 export { OnboardingPreview } from './screens/OnboardingPreview';
 
 // Reusable Components
-export { BrowserPreview } from './components/BrowserPreview';
+export { BrowserPreview } from '../../components/common';
 export { ReviewCard } from './components/ReviewCard';
 export { NavigationStepper } from './components/NavigationStepper';
 export { WebsiteBackground } from './components/WebsiteBackground';

--- a/src/features/client-flow/screens/ClientEditor.tsx
+++ b/src/features/client-flow/screens/ClientEditor.tsx
@@ -13,6 +13,8 @@ export interface ClientEditorProps extends BaseProps {
   unlayerConfig: UnlayerOptions;
   templateId: string; // Required - always edit mode
   onComplete?: () => void;
+  /** Called when user exits editor (e.g. return to review); confirm is shown before calling */
+  onExit?: () => void;
 }
 
 /**
@@ -30,23 +32,25 @@ export const ClientEditor: React.FC<ClientEditorProps> = ({
   templateId,
   unlayerConfig,
   onComplete,
+  onExit,
 }) => {
-  const { loadTemplate } = useBuilderMain({ apiClient });
-  const { actions } = useBuilderStore();
-  const { templateByIdLoading } = useLoadingStore();
-
-  // Local step state for client editor (0 = Editor, 1 = Reminder Tab)
-  const [currentStep, setCurrentStep] = useState(0);
-  const [loadError, setLoadError] = useState<string | null>(null);
-
-  // Sync generic context (account, auth, shoppers, navigate) into global store once
+  // Sync first so apiClient and context are in store before useBuilderMain etc.
   useSyncGenericContext({
     accountDetails,
     authProvider,
     shoppers,
     navigate,
     accounts,
+    apiClient,
   });
+
+  const { loadTemplate } = useBuilderMain();
+  const { actions } = useBuilderStore();
+  const { templateByIdLoading } = useLoadingStore();
+
+  // Local step state for client editor (0 = Editor, 1 = Reminder Tab)
+  const [currentStep, setCurrentStep] = useState(0);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   // Load template on mount
   useEffect(() => {
@@ -124,14 +128,13 @@ export const ClientEditor: React.FC<ClientEditorProps> = ({
       {currentStep === 0 && (
         <ClientEditorStep
           unlayerConfig={unlayerConfig}
-          apiClient={apiClient}
           templateId={templateId}
           onNext={handleNextStep}
+          onExit={onExit}
         />
       )}
       {currentStep === 1 && (
         <ClientReminderTabStep
-          apiClient={apiClient}
           onBack={handlePrevStep}
           onComplete={onComplete}
         />

--- a/src/features/client-flow/screens/CopyReview.tsx
+++ b/src/features/client-flow/screens/CopyReview.tsx
@@ -2,9 +2,7 @@ import React, { useEffect } from 'react';
 import { Row, Col, Card } from 'antd';
 import ContentForm from '../components/content-form';
 import ShopperDetails from '../components/shopper-details';
-import { AxiosInstance } from 'axios';
-import { PopupPreviewTabs } from '../components/PopupPreviewTabs';
-import { BrowserPreviewModal } from '../components/BrowserPreviewModal';
+import { PopupPreviewTabs, BrowserPreviewModal } from '../../../components/common';
 import FeedbackForm from '../components/feedback-form';
 import { useGenericStore } from '@/stores/generic.store';
 import { useClientFlow } from '../hooks/use-client-flow';
@@ -17,14 +15,12 @@ import ShopperSegmentSelector from '../components/shopper-segment-selector';
  * Allows clients to review and customize coupon copy for different scenarios
  * Redesigned with 2-column layout for better space utilization
  */
-interface CopyReviewProps {
-  apiClient: AxiosInstance;
-}
-
-export const CopyReview: React.FC<CopyReviewProps> = ({ apiClient }) => {
-  const { accountDetails, browserPreviewModalOpen, actions: genericActions } = useGenericStore();
+export const CopyReview: React.FC = () => {
+  const accountDetails = useGenericStore((s) => s.accountDetails);
+  const browserPreviewModalOpen = useGenericStore((s) => s.browserPreviewModalOpen);
+  const genericActions = useGenericStore((s) => s.actions);
   const { devices } = useDevicesStore();
-  const { getDevices } = useClientFlow({ apiClient });
+  const { getDevices } = useClientFlow();
   const { clientData } = useClientFlowStore();
 
   useEffect(() => {
@@ -49,10 +45,7 @@ export const CopyReview: React.FC<CopyReviewProps> = ({ apiClient }) => {
           </Card>
           {/* Shopper Details - Collapsible, Open by Default */}
           <div className="mb-4">
-            <ShopperDetails 
-              apiClient={apiClient} 
-              displayMode="full" 
-            />
+            <ShopperDetails displayMode="full" />
           </div>
           
           {/* Content Configuration Form */}

--- a/src/features/client-flow/screens/DesktopReview.tsx
+++ b/src/features/client-flow/screens/DesktopReview.tsx
@@ -2,8 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Card, Col, Row, Tag, Popover, Button, Alert, Spin, Tooltip, Divider } from 'antd';
 import { Info } from 'lucide-react';
 import FeedbackForm from '../components/feedback-form';
-import { PopupOnlyView } from '../components/PopupOnlyView';
-import { BrowserPreviewModal } from '../components/BrowserPreviewModal';
+import { PopupOnlyView, BrowserPreviewModal } from '../../../components/common';
 import { useGenericStore } from '@/stores/generic.store';
 import ReviewActions from '../components/review-actions';
 import { useClientFlowStore } from '@/stores/clientFlowStore';
@@ -24,14 +23,16 @@ export const DesktopReview: React.FC<DesktopReviewProps> = ({ }) => {
   const [template, setTemplate] = useState<ClientFlowData | null>(null);
   const getPreviewTemplate = () => {
     if (clientData && clientData.length) {
-      return clientData.filter(
-        (template) =>
-          template.devices.find((device) => device.device_type === 'desktop') &&
-          template.staging_status === 'client-review'
+      const withDesktop = clientData.filter(
+        (t) =>
+          t.staging_status === 'client-review' &&
+          t.devices?.some((d) => String(d.device_type).toLowerCase() === 'desktop')
       );
-    } else {
-      return [];
+      if (withDesktop.length) return withDesktop;
+      // Fallback: show first client-review template so preview/actions are visible
+      return clientData.filter((t) => t.staging_status === 'client-review');
     }
+    return [];
   };
 
   const onEditTemplate = () => {

--- a/src/features/client-flow/screens/LandingPreview.tsx
+++ b/src/features/client-flow/screens/LandingPreview.tsx
@@ -4,7 +4,7 @@ import { BaseProps } from '../../../types/props';
 import {
   BrowserPreview,
   BrowserPreviewSkeleton,
-} from '../components/BrowserPreview';
+} from '../../../components/common';
 import { useClientFlowStore } from '../../../stores/clientFlowStore';
 import type { ViewportType } from '../types/clientFlow';
 import { ALargeSmall, Computer, TabletSmartphone } from 'lucide-react';
@@ -35,19 +35,19 @@ export const LandingPreview: React.FC<LandingPreviewProps> = ({
   accountDetails,
   goToReview
 }) => {
-  // TODO: Integrate BaseProps with API calls and navigation
-  // For now, these props are available for future API integration
-  const { actions, error, clientData } = useClientFlowStore();
-  const { getCleintTemplatesData } = useClientFlow({ apiClient });
-  const { clientTemplateDetailsLoading } = useLoadingStore();
-  // Sync generic context (account, auth, shoppers, navigate) into global store once
+  // Sync first so apiClient and context are in store before useClientFlow etc.
   useSyncGenericContext({
     accountDetails,
     authProvider,
     shoppers,
     navigate,
     accounts,
+    apiClient,
   });
+
+  const { actions, error, clientData } = useClientFlowStore();
+  const { getCleintTemplatesData } = useClientFlow();
+  const { clientTemplateDetailsLoading } = useLoadingStore();
 
   // Fixed desktop preview for landing page
   const viewport: ViewportType = 'desktop';
@@ -221,7 +221,6 @@ export const LandingPreview: React.FC<LandingPreviewProps> = ({
                     interactive={false}
                     scale={0.9}
                     onPopupInteraction={(action) => {
-                      console.log('Popup interaction:', action);
                     }}
                   />
                 ) : (

--- a/src/features/client-flow/screens/MobileReview.tsx
+++ b/src/features/client-flow/screens/MobileReview.tsx
@@ -14,8 +14,7 @@ import {
   Tooltip,
 } from 'antd';
 
-import { PopupOnlyView } from '../components/PopupOnlyView';
-import { BrowserPreviewModal } from '../components/BrowserPreviewModal';
+import { PopupOnlyView, BrowserPreviewModal } from '../../../components/common';
 import { useClientFlowStore } from '../../../stores/clientFlowStore';
 import { Clock, Smartphone, Info } from 'lucide-react';
 import FeedbackForm from '../components/feedback-form';
@@ -39,14 +38,15 @@ export const MobileReview: React.FC<MobileReviewProps> = ({ }) => {
 
   const getPreviewTemplate = () => {
     if (clientData && clientData.length) {
-      return clientData.filter(
-        (template) =>
-          template.devices.find((device) => device.device_type === 'mobile') &&
-          template.staging_status === 'client-review'
+      const withMobile = clientData.filter(
+        (t) =>
+          t.staging_status === 'client-review' &&
+          t.devices?.some((d) => String(d.device_type).toLowerCase() === 'mobile')
       );
-    } else {
-      return [];
+      if (withMobile.length) return withMobile;
+      return clientData.filter((t) => t.staging_status === 'client-review');
     }
+    return [];
   };
 
   const onEditTemplate = () => {

--- a/src/features/client-flow/screens/OnboardingPreview.tsx
+++ b/src/features/client-flow/screens/OnboardingPreview.tsx
@@ -25,6 +25,16 @@ export const OnboardingPreview: React.FC<OnboardingPreviewProps> = ({
   accounts,
   className = '',
 }) => {
+  // Sync first so apiClient and context are in store before useClientFlow etc.
+  useSyncGenericContext({
+    accountDetails,
+    authProvider,
+    shoppers,
+    navigate,
+    accounts,
+    apiClient,
+  });
+
   const {
     clientData,
     currentStep,
@@ -35,18 +45,8 @@ export const OnboardingPreview: React.FC<OnboardingPreviewProps> = ({
     error,
     contentFields,
   } = useClientFlowStore();
-  const { getCleintTemplatesData, getContentFieldsWithContent } = useClientFlow({
-    apiClient,
-  });
+  const { getCleintTemplatesData, getContentFieldsWithContent } = useClientFlow();
   const { clientTemplateDetailsLoading } = useLoadingStore();
-
-  useSyncGenericContext({
-    accountDetails,
-    authProvider,
-    shoppers,
-    navigate,
-    accounts,
-  });
 
   useEffect(() => {
     if (accountDetails && !clientData) {
@@ -57,26 +57,17 @@ export const OnboardingPreview: React.FC<OnboardingPreviewProps> = ({
     }
   }, [accountDetails]);
 
-  // Render current step content
+  // Render current step content (apiClient and context from generic store)
   const renderStepContent = () => {
-    const stepProps = {
-      apiClient,
-      navigate,
-      shoppers,
-      accountDetails,
-      authProvider,
-      accounts,
-    };
-
     switch (currentStep) {
       case 0:
-        return <DesktopReview {...stepProps} />;
+        return <DesktopReview />;
       case 1:
-        return <MobileReview {...stepProps} />;
+        return <MobileReview />;
       case 2:
-        return <CopyReview {...stepProps} />;
+        return <CopyReview />;
       case 3:
-        return <ReviewScreen {...stepProps} />;
+        return <ReviewScreen />;
       default:
         return (
           <div className="text-center py-12">

--- a/src/features/client-flow/screens/ReviewScreen.tsx
+++ b/src/features/client-flow/screens/ReviewScreen.tsx
@@ -7,7 +7,7 @@ import {
   FileTextOutlined
 } from '@ant-design/icons';
 import { Clock, FileCheck } from 'lucide-react';
-import { BrowserPreview, BrowserPreviewSkeleton } from '../components/BrowserPreview';
+import { BrowserPreview, BrowserPreviewSkeleton } from '../../../components/common';
 import { useClientFlowStore } from '@/stores/clientFlowStore';
 import { useGenericStore } from '@/stores/generic.store';
 import { ClientFlowData } from '@/types';
@@ -210,7 +210,6 @@ export const ReviewScreen: React.FC<ReviewScreenProps> = () => {
                 interactive={false}
                 scale={0.9}
                 onPopupInteraction={(action) => {
-                  console.log(`${selectedDevice} interaction:`, action);
                 }}
               />
             ) : (

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -1,6 +1,5 @@
 // Feature exports
 export * from './template-builder';
-export * from './template-designer';
 export * from './canned-content';
 export * from './builder';
 export * from './client-flow';

--- a/src/features/template-builder/components/common/StatusTag.tsx
+++ b/src/features/template-builder/components/common/StatusTag.tsx
@@ -8,15 +8,16 @@ interface StatusTagProps {
 }
 
 export const StatusTag: React.FC<StatusTagProps> = ({ status }) => {
-  const statusConfig = {
+  const statusConfig: Record<string, { color: string; text: string }> = {
     draft: { color: 'default', text: 'Draft' },
     published: { color: 'success', text: 'Published' },
     archive: { color: 'warning', text: 'Archived' },
+    'client-review': { color: 'processing', text: 'Client Review' },
   };
 
-  const config = statusConfig[status as keyof typeof statusConfig];
+  const config = status ? statusConfig[status] : undefined;
 
-  return <Tag color={config.color}>{config.text}</Tag>;
+  return <Tag color={config?.color}>{config?.text ?? status ?? '—'}</Tag>;
 };
 
 export default StatusTag;

--- a/src/features/template-builder/components/common/link-template-modal.tsx
+++ b/src/features/template-builder/components/common/link-template-modal.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Modal, Form, Select, Button, message, Typography, Tag, Space, Divider, Empty } from 'antd';
 import { LinkOutlined, UserOutlined, MobileOutlined } from '@ant-design/icons';
 import { createAPI } from '@/api';
-import { AxiosInstance } from 'axios';
+import { useGenericStore } from '@/stores/generic.store';
 
 const { Text, Title } = Typography;
 const { Option } = Select;
@@ -21,7 +21,6 @@ interface LinkTemplateModalProps {
   parentTemplateId: string;
   parentTemplateName?: string;
   accountId: number;
-  apiClient: AxiosInstance;
   onSuccess?: () => void;
 }
 
@@ -31,17 +30,17 @@ export const LinkTemplateModal: React.FC<LinkTemplateModalProps> = ({
   parentTemplateId,
   parentTemplateName,
   accountId,
-  apiClient,
   onSuccess,
 }) => {
+  const apiClient = useGenericStore((s) => s.apiClient);
   const [form] = Form.useForm();
   const [loading, setLoading] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [potentialTemplates, setPotentialTemplates] = useState<PotentialChildTemplate[]>([]);
   const [selectedTemplates, setSelectedTemplates] = useState<string[]>([]);
 
-  const api = createAPI(apiClient);
-  const templatesAPI = api.templates;
+  const api = apiClient ? createAPI(apiClient) : null;
+  const templatesAPI = api?.templates;
 
   useEffect(() => {
     if (visible && accountId) {
@@ -50,6 +49,7 @@ export const LinkTemplateModal: React.FC<LinkTemplateModalProps> = ({
   }, [visible, accountId]);
 
   const fetchPotentialChildTemplates = async () => {
+    if (!templatesAPI) return;
     setLoading(true);
     try {
       const response = await templatesAPI.getPotentitalChildTemplateDetails(accountId);
@@ -65,6 +65,10 @@ export const LinkTemplateModal: React.FC<LinkTemplateModalProps> = ({
   };
 
   const handleSubmit = async () => {
+    if (!templatesAPI) {
+      message.error('API client is required');
+      return;
+    }
     if (selectedTemplates.length === 0) {
       message.warning('Please select at least one template to link');
       return;

--- a/src/features/template-builder/hooks/use-template-listing.ts
+++ b/src/features/template-builder/hooks/use-template-listing.ts
@@ -4,18 +4,14 @@ import { useTemplateListingStore } from '@/stores/list/templateListing.store';
 import { useDevicesStore } from '@/stores/common/devices.store';
 import { useLoadingStore } from '@/stores/common/loading.store';
 import { useGenericStore } from '@/stores/generic.store';
-import { AxiosInstance } from 'axios';
-import { CleanTemplateResponse, TemplateAction, TCBTemplate } from '@/types';
+import { CleanTemplateResponse, TemplateAction } from '@/types';
 import { convertMultipleUnlayerDesignsToHtml, validateUnlayerDesign, type BatchConversionItem } from '@/lib/utils/batchUnlayerConverter';
 
-export const useTemplateListing = ({
-  apiClient,
-}: {
-  apiClient: AxiosInstance;
-}) => {
-  const { navigate } = useGenericStore();
+export const useTemplateListing = () => {
+  const apiClient = useGenericStore((s) => s.apiClient);
+  const navigate = useGenericStore((s) => s.navigate);
 
-  const api = createAPI(apiClient);
+  const api = apiClient ? createAPI(apiClient) : null;
 
   const { devices, actions: deviceActions } = useDevicesStore();
   const { actions: loadingActions } = useLoadingStore();
@@ -23,41 +19,55 @@ export const useTemplateListing = ({
 
   const handleAction = async (
     action: TemplateAction,
-    template: CleanTemplateResponse
+    template: CleanTemplateResponse,
+    options?: { targetStatus?: 'draft' | 'published' }
   ) => {
-    console.log(`Handling action ${action} for template ${template.id}`);
+    if (!api && action !== 'edit' && action !== 'preview') {
+      message.error('API client is required');
+      return;
+    }
     try {
       switch (action) {
         case 'edit':
-          console.log(`Navigating to edit template ${template.id}`, navigate);
-          navigate(`/coupon-builder-v2/popup-builder/${template.id}/edit`);
+          navigate?.(`/coupon-builder-v2/popup-builder/${template.id}/edit`);
           break;
         case 'preview':
-          navigate(`/coupon-builder-v2/popup-builder/${template.id}/preview`);
+          navigate?.(`/coupon-builder-v2/popup-builder/${template.id}/preview`);
           break;
-        // case 'publish':
-        //   await publishTemplate(template.id);
-        //   getTemplates();
-        //   break;
         case 'client-review':
           await pushTemplateToClientReview(template);
           message.success('Template pushed to client review successfully');
           getTemplates();
           break;
         case 'archive':
-          await api.templates.archiveTemplate(template.id);
-          message.success('Template archived successfully');
-          getTemplates();
+          loadingActions.setTemplateListActionLoading(true);
+          try {
+            await api!.templates.archiveTemplate(template.id);
+            message.success('Template archived successfully');
+            getTemplates();
+          } finally {
+            loadingActions.setTemplateListActionLoading(false);
+          }
           break;
         case 'unarchive':
-          await api.templates.unarchiveTemplate(template.id);
-          message.success('Template unarchived successfully');
-          getTemplates();
+          loadingActions.setTemplateListActionLoading(true);
+          try {
+            await api!.templates.unarchiveTemplate(template.id, options?.targetStatus);
+            message.success('Template unarchived successfully');
+            getTemplates();
+          } finally {
+            loadingActions.setTemplateListActionLoading(false);
+          }
           break;
         case 'delete':
-          await api.templates.deleteTemplate(template.id);
-          message.success('Template deleted successfully');
-          getTemplates();
+          loadingActions.setTemplateListActionLoading(true);
+          try {
+            await api!.templates.deleteTemplate(template.id);
+            message.success('Template deleted successfully');
+            getTemplates();
+          } finally {
+            loadingActions.setTemplateListActionLoading(false);
+          }
           break;
       }
     } catch (error) {
@@ -67,9 +77,19 @@ export const useTemplateListing = ({
   };
 
   const getTemplates = async () => {
+    if (!api) {
+      message.error('API client is required');
+      return;
+    }
     loadingActions.setTemplateListingLoading(true);
     try {
-      const response = await api.templates.getTemplatesForUI();
+      // Read fresh state at call time so filters/search/sort applied just before fetch are used
+      const { filters: f, pagination: p, sorter: s } = useTemplateListingStore.getState();
+      const response = await api.templates.getTemplatesForUI({
+        filters: f,
+        pagination: p,
+        sorter: s,
+      });
       actions.setTemplates(response.templates);
       actions.setPagination({
         current: response.pagination.page,
@@ -87,15 +107,20 @@ export const useTemplateListing = ({
   const pushTemplateToClientReview = async (
     template: CleanTemplateResponse
   ) => {
+    if (!api) {
+      message.error('API client is required');
+      return;
+    }
+
     loadingActions.setTemplateListActionLoading(true);
     try {
       // Prepare batch conversion items
       const conversionItems: BatchConversionItem[] = [];
-      
+
       // Helper function to prepare template for batch conversion
       const prepareTemplateForConversion = (templateData: any, templateId: string) => {
         if (!templateData.builder_state_json) return null;
-        
+
         // Parse JSON if it's a string
         let designData = templateData.builder_state_json;
         if (typeof designData === 'string') {
@@ -120,17 +145,21 @@ export const useTemplateListing = ({
       };
 
       // Add parent template to batch
-      const parentItem = prepareTemplateForConversion(template, template.id);
-      if (parentItem) {
-        conversionItems.push(parentItem);
+      if(template.status === 'draft') {
+        const parentItem = prepareTemplateForConversion(template, template.id);
+        if (parentItem) {
+          conversionItems.push(parentItem);
+        }
       }
 
       // Add child templates to batch
       if (template.child_templates && template.child_templates.length > 0) {
         for (const childTemplate of template.child_templates) {
-          const childItem = prepareTemplateForConversion(childTemplate, childTemplate.id);
-          if (childItem) {
-            conversionItems.push(childItem);
+          if (childTemplate.status === 'draft') {
+            const childItem = prepareTemplateForConversion(childTemplate, childTemplate.id);
+            if (childItem) {
+              conversionItems.push(childItem);
+            }
           }
         }
       }
@@ -143,7 +172,6 @@ export const useTemplateListing = ({
       }
 
       // Batch convert all templates using single editor instance
-      console.log(`🔄 Starting batch conversion of ${conversionItems.length} templates...`);
       const conversionResults = await convertMultipleUnlayerDesignsToHtml(conversionItems, {
         projectId: 123,
         timeout: 30000, // 30 second total timeout
@@ -167,18 +195,18 @@ export const useTemplateListing = ({
       // Push to client review with templates array
       if (templatesData.length > 0) {
         await api.templates.pushTemplateToClientReview(templatesData);
-        
+
         const childCount = templatesData.length - 1;
         const failedCount = conversionResults.length - templatesData.length;
-        
-        let successMessage = childCount > 0 
+
+        let successMessage = childCount > 0
           ? `Template and ${childCount} child template(s) published successfully`
           : 'Template published successfully';
-          
+
         if (failedCount > 0) {
           successMessage += ` (${failedCount} template(s) failed conversion)`;
         }
-        
+
         message.success(successMessage);
       } else {
         message.error(
@@ -193,67 +221,11 @@ export const useTemplateListing = ({
     }
   };
 
-  // const publishTemplate = async (templateId: string) => {
-  //   loadingActions.setTemplateListActionLoading(true);
-  //   try {
-  //     // Get template data to access builder_state_json
-  //     console.log(`🚀 Publishing template ${templateId}...`);
-  //     const template = await api.templates.getTemplateById(templateId);
-
-  //     let htmlContent: string | undefined;
-
-  //     // Check if template has design data for HTML conversion
-  //     if (template.builder_state_json) {
-  //       console.log('📄 Template has design data, converting to HTML...');
-
-  //       // Parse JSON if it's a string
-  //       let designData = template.builder_state_json;
-  //       if (typeof designData === 'string') {
-  //         try {
-  //           designData = JSON.parse(designData);
-  //         } catch (parseError) {
-  //           console.warn('⚠️ Failed to parse builder_state_json:', parseError);
-  //           // Continue without HTML conversion
-  //         }
-  //       }
-
-  //       // Validate and convert design to HTML
-  //       if (designData && validateUnlayerDesign(designData)) {
-  //         try {
-  //           console.log('🔄 Converting Unlayer design to HTML...');
-  //           htmlContent = await convertUnlayerJsonToHtml(designData, {
-  //             projectId: 123, // Default project ID
-  //             timeout: 15000, // 15 second timeout
-  //           });
-  //           console.log('✅ HTML conversion successful');
-  //         } catch (conversionError) {
-  //           console.warn('⚠️ HTML conversion failed:', conversionError);
-  //           message.warning(
-  //             'HTML conversion failed, publishing without HTML content'
-  //           );
-  //           // Continue with publish without HTML
-  //         }
-  //       } else {
-  //         console.warn('⚠️ Invalid or missing Unlayer design data');
-  //       }
-  //     } else {
-  //       console.log(
-  //         '📝 Template has no design data, publishing without HTML conversion'
-  //       );
-  //     }
-
-  //     // Publish template with or without HTML content
-  //     await api.templates.publishTemplate(templateId, htmlContent);
-  //     message.success('Template published successfully');
-  //   } catch (error) {
-  //     console.error('❌ Error publishing template:', error);
-  //     message.error('Failed to publish template');
-  //   } finally {
-  //     loadingActions.setTemplateListActionLoading(false);
-  //   }
-  // };
-
   const getDevices = async () => {
+    if (!api) {
+      message.error('API client is required');
+      return;
+    }
     if (devices.length > 0) return;
 
     loadingActions.setDevicesLoading(true);

--- a/src/features/template-designer/index.ts
+++ b/src/features/template-designer/index.ts
@@ -1,2 +1,0 @@
-// Template designer components will be exported here
-export {};

--- a/src/lib/components/index.ts
+++ b/src/lib/components/index.ts
@@ -1,2 +1,0 @@
-// React component utilities
-export { default as dynamicImportLucideIcon } from '../utils/dynamic-icons';

--- a/src/lib/hooks/index.ts
+++ b/src/lib/hooks/index.ts
@@ -1,5 +1,7 @@
 // Hooks exports
+export { useApiClient } from './use-api-client';
 export { useDebouncedCallback } from './use-debounce';
 export { useIsMobile } from './use-mobile';
 export { useSyncGenericContext } from './use-sync-generic-context';
 export { useOptimizedHTMLMerger } from './use-optimized-html-merger';
+export { useTemplatePreviewData } from './use-template-preview-data';

--- a/src/lib/hooks/use-action-confirm.tsx
+++ b/src/lib/hooks/use-action-confirm.tsx
@@ -1,5 +1,4 @@
 import { Modal } from 'antd';
-import { ModalConfig } from 'antd/es/config-provider/context';
 import { useCallback, useState } from 'react';
 
 type UseActionConfirmOptions = {
@@ -7,6 +6,10 @@ type UseActionConfirmOptions = {
   content?: React.ReactNode;
   onConfirm?: () => void | Promise<void>;
   onCancel?: () => void;
+};
+
+type ConfirmModalProps = {
+  confirmLoading?: boolean;
 };
 
 export const useActionConfirm = () => {
@@ -19,10 +22,10 @@ export const useActionConfirm = () => {
   }, []);
 
   const handleConfirm = useCallback(async () => {
-    setIsVisible(false);
     if (options.onConfirm) {
       await options.onConfirm();
     }
+    setIsVisible(false);
   }, [options]);
 
   const handleCancel = useCallback(() => {
@@ -32,20 +35,26 @@ export const useActionConfirm = () => {
     }
   }, [options]);
 
-  const ConfirmModal = useCallback(() => {
-    return (
-      <Modal
-        title={options.title || 'Are you sure?'}
-        open={isVisible}
-        onOk={handleConfirm}
-        onCancel={handleCancel}
-        okText="Confirm"
-        cancelText="Cancel"
-      >
-        {options.content || 'This action cannot be undone.'}
-      </Modal>
-    );
-  }, [isVisible, options, handleConfirm, handleCancel]);
+  const ConfirmModal = useCallback(
+    ({ confirmLoading = false }: ConfirmModalProps) => {
+      return (
+        <Modal
+          title={options.title || 'Are you sure?'}
+          open={isVisible}
+          onOk={handleConfirm}
+          onCancel={handleCancel}
+          okText="Confirm"
+          cancelText="Cancel"
+          okButtonProps={{ loading: confirmLoading }}
+          maskClosable={!confirmLoading}
+          closable={!confirmLoading}
+        >
+          {options.content || 'This action cannot be undone.'}
+        </Modal>
+      );
+    },
+    [isVisible, options, handleConfirm, handleCancel]
+  );
 
   return { showConfirm, ConfirmModal };
 };

--- a/src/lib/hooks/use-api-client.ts
+++ b/src/lib/hooks/use-api-client.ts
@@ -1,0 +1,7 @@
+import { useGenericStore } from '@/stores/generic.store';
+
+/**
+ * Returns the API client from the generic store (synced via useSyncGenericContext).
+ * Use this instead of prop-drilling apiClient.
+ */
+export const useApiClient = () => useGenericStore((s) => s.apiClient);

--- a/src/lib/hooks/use-template-preview-data.ts
+++ b/src/lib/hooks/use-template-preview-data.ts
@@ -1,0 +1,197 @@
+import { useState, useEffect, useMemo } from 'react';
+import { AxiosInstance } from 'axios';
+import { createAPI } from '@/api';
+import { CleanTemplateResponse, ClientFlowData } from '@/types';
+import { BaseTemplate } from '@/features/base-template/types';
+import {
+  convertBaseTemplateToClientFlowData,
+  convertCleanTemplateToClientFlowData,
+} from '@/lib/utils/template-to-client-flow-converter';
+import { useGenericStore } from '@/stores/generic.store';
+import { useDevicesStore } from '@/stores/common/devices.store';
+
+interface UseTemplatePreviewDataOptions {
+  /**
+   * BaseTemplate object (for direct conversion without API call)
+   */
+  template?: BaseTemplate | CleanTemplateResponse | null;
+  
+  /**
+   * Template ID to fetch from API (uses apiClient from store or option)
+   */
+  templateId?: string | null;
+  
+  /**
+   * API client instance (optional; when not provided, uses apiClient from generic store)
+   */
+  apiClient?: AxiosInstance;
+  
+  /**
+   * Whether to fetch data (useful for conditional fetching)
+   */
+  enabled?: boolean;
+  
+  /**
+   * Custom HTML content to use instead of template's html_content
+   */
+  htmlContent?: string | null;
+}
+
+interface UseTemplatePreviewDataReturn {
+  /**
+   * Converted ClientFlowData array (ready for PopupPreviewTabs)
+   */
+  previewData: ClientFlowData[] | null;
+  
+  /**
+   * Loading state (true when fetching from API)
+   */
+  loading: boolean;
+  
+  /**
+   * Error message if conversion/fetching failed
+   */
+  error: string | null;
+  
+  /**
+   * Manually trigger data refresh
+   */
+  refetch: () => Promise<void>;
+}
+
+/**
+ * Hook to get template preview data in ClientFlowData format
+ * 
+ * Supports two modes:
+ * 1. Direct conversion from BaseTemplate (no API call, instant)
+ * 2. Fetch from API using templateId (requires apiClient)
+ * 
+ * @example
+ * // Direct conversion (no API call)
+ * const { previewData, loading } = useTemplatePreviewData({
+ *   baseTemplate: template,
+ *   enabled: previewModalVisible
+ * });
+ * 
+ * @example
+ * // Fetch from API
+ * const { previewData, loading } = useTemplatePreviewData({
+ *   templateId: template.template_id,
+ *   apiClient: apiClient,
+ *   enabled: previewModalVisible
+ * });
+ */
+export function useTemplatePreviewData(
+  options: UseTemplatePreviewDataOptions
+): UseTemplatePreviewDataReturn {
+  const {
+    template,
+    templateId,
+    apiClient: apiClientOption,
+    enabled = true,
+    htmlContent,
+  } = options;
+
+  const apiClientFromStore = useGenericStore((s) => s.apiClient);
+  const apiClient = apiClientOption ?? apiClientFromStore;
+  const storeDevices = useDevicesStore((s) => s.devices);
+
+  const [previewData, setPreviewData] = useState<ClientFlowData[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Merge devices from store into clientData so PopupPreviewTabs has desktop + mobile etc.
+  const mergeDevicesIntoPreviewData = useMemo(() => {
+    const devicesForMerge =
+      storeDevices.length > 0
+        ? storeDevices.map((d) => ({ id: d.id, device_type: d.device_type }))
+        : null;
+    return (data: ClientFlowData[] | null): ClientFlowData[] | null => {
+      if (!data || !data.length) return data;
+      if (!devicesForMerge || !devicesForMerge.length) return data;
+      return data.map((item) => ({
+        ...item,
+        devices: devicesForMerge,
+        device_type_ids: devicesForMerge.map((d) => d.id),
+      }));
+    };
+  }, [storeDevices]);
+
+  // Direct conversion from BaseTemplate (no API call)
+  const directPreviewData = useMemo<ClientFlowData[] | null>(() => {
+    if (!enabled || !template) {
+      return null;
+    }
+
+    try {
+      const converted = convertBaseTemplateToClientFlowData(template, htmlContent);
+      const data = converted ? [converted] : null;
+      return data ? mergeDevicesIntoPreviewData(data) : null;
+    } catch (err) {
+      console.error('Failed to convert base template:', err);
+      return null;
+    }
+  }, [template, htmlContent, enabled, mergeDevicesIntoPreviewData]);
+
+  // Fetch from API using templateId
+  const fetchTemplateData = async () => {
+    if (!enabled || !templateId || !apiClient) {
+      setPreviewData(null);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const api = createAPI(apiClient);
+      const templateResponse = await api.templates.getTemplateById(templateId);
+      if (templateResponse) {
+        // HTML content might not be in CleanTemplateResponse, use provided htmlContent or empty string
+        const converted = convertCleanTemplateToClientFlowData(
+          templateResponse,
+          htmlContent || ''
+        );
+        const raw = converted ? [converted] : null;
+        setPreviewData(mergeDevicesIntoPreviewData(raw));
+      } else {
+        setPreviewData(null);
+        setError('Template not found');
+      }
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to fetch template data';
+      console.error('Failed to fetch template data for preview:', err);
+      setError(errorMessage);
+      setPreviewData(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Run only when enabled so callers can gate until e.g. preview HTML is ready
+  useEffect(() => {
+    if (!enabled) {
+      setPreviewData(null);
+      setLoading(false);
+      return;
+    }
+    if (template && htmlContent) {
+      setPreviewData(directPreviewData);
+      setLoading(false);
+      setError(null);
+    } else if (templateId && apiClient) {
+      fetchTemplateData();
+    } else {
+      setPreviewData(null);
+      setLoading(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [template, directPreviewData, templateId, apiClient, enabled]);
+
+  return {
+    previewData,
+    loading,
+    error,
+    refetch: fetchTemplateData,
+  };
+}

--- a/src/lib/utils/field-highlight-engine.ts
+++ b/src/lib/utils/field-highlight-engine.ts
@@ -145,8 +145,6 @@ export class FieldHighlightEngine {
       console.warn(`[Field Highlight] Could not find element for field ID: ${fieldId}`);
       return;
     }
-    
-    console.log(`[Field Highlight] Highlighting field: ${fieldId}`, element);
 
     // Apply highlight class
     requestAnimationFrame(() => {

--- a/src/lib/utils/helper.ts
+++ b/src/lib/utils/helper.ts
@@ -220,7 +220,7 @@ export const safeDecodeAndSanitizeHtml = async (encodedHtml: string): Promise<st
       ],
       ALLOWED_ATTR: [
         // Standard attributes
-        'href', 'src', 'alt', 'class', 'id', 'style', 'title',
+        'href', 'src', 'alt', 'class', 'id', 'style', 'title', 'aria-label',
         // Layout attributes
         'width', 'height', 'align', 'valign',
         // Form attributes

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,5 +1,6 @@
 // General utilities
 export * from './helper';
 export * from './unlayerHtmlConverter';
+export * from './template-to-client-flow-converter';
 
 // Builder-specific utilities removed during cleanup

--- a/src/lib/utils/popup-reminder-tab-html-merger.ts
+++ b/src/lib/utils/popup-reminder-tab-html-merger.ts
@@ -326,14 +326,18 @@ class DynamicHTMLMerger {
     const hasMobile = mobileConfig?.enabled && config.enabled;
     
     return `<script>
-  ${hasDesktop ? `class ReminderTab{constructor(){this.tab=document.getElementById("reminderTab"),this.dragger=this.tab?.querySelector(".reminder-tab-dragger"),this.isDragging=!1,this.currentPosition="${desktopConfig?.display?.position || 'right'}",this.dragTimeout=null,this.init()}init(){if(!this.tab)return;${desktopConfig?.interactions?.clicking?.enabled !== false ? 'this.tab.addEventListener("click",t=>{this.isDragging||t.target===this.dragger||this.openPopup()});' : ''}${desktopConfig?.interactions?.dragging?.enabled ? 'this.addDragListeners();' : ''}}${desktopConfig?.interactions?.dragging?.enabled ? `addDragListeners(){if(!this.dragger)return;this.dragger.addEventListener("mousedown",t=>{t.stopPropagation(),t.preventDefault(),this.startDrag()}),this.dragger.addEventListener("touchstart",t=>{t.stopPropagation(),t.preventDefault(),this.startDrag()},{passive:!1}),document.addEventListener("mousemove",t=>this.drag(t)),document.addEventListener("mouseup",()=>this.endDrag()),document.addEventListener("touchmove",t=>this.drag(t.touches[0]),{passive:!1}),document.addEventListener("touchend",()=>this.endDrag())}startDrag(){this.isDragging=!0,this.tab.classList.add("dragging"),document.body.style.userSelect="none"}drag(t){if(!this.isDragging)return;const e=t.clientX,i=t.clientY,s=window.innerWidth,n=window.innerHeight,r=this.tab.offsetHeight;let o=i-r/2;o=Math.max(0,Math.min(o,n-r));const a=e<s/2?"left":"right";a!==this.currentPosition&&this.updatePosition(a),this.tab.style.top=o+"px",this.tab.style.transform="none"}endDrag(){this.isDragging&&(this.isDragging=!1,this.tab.classList.remove("dragging"),document.body.style.userSelect="",clearTimeout(this.dragTimeout),this.dragTimeout=setTimeout(()=>{this.isDragging=!1},150))}updatePosition(t){this.tab.classList.remove("position-left","position-right"),this.tab.classList.add(\`position-\${t}\`),this.currentPosition=t}` : ''}openPopup(){const t=new CustomEvent("openReminderPopup",{detail:{source:"reminderTab"}});document.dispatchEvent(t),"function"==typeof window.openReminderPopup&&window.openReminderPopup()}setText(t){const e=this.tab?.querySelector(".reminder-tab-text");e&&(e.textContent=t)}setPosition(t){"left"!==t&&"right"!==t||this.updatePosition(t)}show(){this.tab&&(this.tab.style.display="flex")}hide(){this.tab&&(this.tab.style.display="none")}getPosition(){return this.currentPosition}}` : ''}
+  (function(){
+    if(window.__reminderTabScriptLoaded)return;
+    window.__reminderTabScriptLoaded=true;
+  ${hasDesktop ? `const ReminderTab=class{constructor(){this.tab=document.getElementById("reminderTab"),this.dragger=this.tab?.querySelector(".reminder-tab-dragger"),this.isDragging=!1,this.currentPosition="${desktopConfig?.display?.position || 'right'}",this.dragTimeout=null,this.init()}init(){if(!this.tab)return;${desktopConfig?.interactions?.clicking?.enabled !== false ? 'this.tab.addEventListener("click",t=>{this.isDragging||t.target===this.dragger||this.openPopup()});' : ''}${desktopConfig?.interactions?.dragging?.enabled ? 'this.addDragListeners();' : ''}}${desktopConfig?.interactions?.dragging?.enabled ? `addDragListeners(){if(!this.dragger)return;this.dragger.addEventListener("mousedown",t=>{t.stopPropagation(),t.preventDefault(),this.startDrag()}),this.dragger.addEventListener("touchstart",t=>{t.stopPropagation(),t.preventDefault(),this.startDrag()},{passive:!1}),document.addEventListener("mousemove",t=>this.drag(t)),document.addEventListener("mouseup",()=>this.endDrag()),document.addEventListener("touchmove",t=>this.drag(t.touches[0]),{passive:!1}),document.addEventListener("touchend",()=>this.endDrag())}startDrag(){this.isDragging=!0,this.tab.classList.add("dragging"),document.body.style.userSelect="none"}drag(t){if(!this.isDragging)return;const e=t.clientX,i=t.clientY,s=window.innerWidth,n=window.innerHeight,r=this.tab.offsetHeight;let o=i-r/2;o=Math.max(0,Math.min(o,n-r));const a=e<s/2?"left":"right";a!==this.currentPosition&&this.updatePosition(a),this.tab.style.top=o+"px",this.tab.style.transform="none"}endDrag(){this.isDragging&&(this.isDragging=!1,this.tab.classList.remove("dragging"),document.body.style.userSelect="",clearTimeout(this.dragTimeout),this.dragTimeout=setTimeout(()=>{this.isDragging=!1},150))}updatePosition(t){this.tab.classList.remove("position-left","position-right"),this.tab.classList.add(\`position-\${t}\`),this.currentPosition=t}` : ''}openPopup(){const t=new CustomEvent("openReminderPopup",{detail:{source:"reminderTab"}});document.dispatchEvent(t),"function"==typeof window.openReminderPopup&&window.openReminderPopup()}setText(t){const e=this.tab?.querySelector(".reminder-tab-text");e&&(e.textContent=t)}setPosition(t){"left"!==t&&"right"!==t||this.updatePosition(t)}show(){this.tab&&(this.tab.style.display="flex")}hide(){this.tab&&(this.tab.style.display="none")}getPosition(){return this.currentPosition}}` : ''}
 
-  ${hasMobile ? `class MobileFloatingButton{constructor(){this.button=document.getElementById("mobileFloatingButton"),this.init()}init(){this.button&&this.button.addEventListener("click",()=>{this.openPopup()})}openPopup(){const t=new CustomEvent("openReminderPopup",{detail:{source:"mobileButton"}});document.dispatchEvent(t),"function"==typeof window.openReminderPopup&&window.openReminderPopup()}show(){this.button&&(this.button.style.display="flex")}hide(){this.button&&(this.button.style.display="none")}}` : ''}
+  ${hasMobile ? `const MobileFloatingButton=class{constructor(){this.button=document.getElementById("mobileFloatingButton"),this.init()}init(){this.button&&this.button.addEventListener("click",()=>{this.openPopup()})}openPopup(){const t=new CustomEvent("openReminderPopup",{detail:{source:"mobileButton"}});document.dispatchEvent(t),"function"==typeof window.openReminderPopup&&window.openReminderPopup()}show(){this.button&&(this.button.style.display="flex")}hide(){this.button&&(this.button.style.display="none")}}` : ''}
 
   document.addEventListener("DOMContentLoaded",function(){
     ${hasDesktop ? 'window.reminderTab=new ReminderTab;' : ''}
     ${hasMobile ? 'window.mobileFloatingButton=new MobileFloatingButton;' : ''}
   });
+  })();
   </script>`;
   }
 
@@ -436,7 +440,18 @@ export class OptimizedHTMLMerger {
       .map((style) => style.outerHTML)
       .join('\n');
 
-    const reminderBody = reminderDoc.body ? reminderDoc.body.innerHTML : '';
+    let reminderBody = reminderDoc.body ? reminderDoc.body.innerHTML : '';
+
+    // When hideReminderTab is true, remove tab/button from DOM so they never render
+    if (config.hideReminderTab) {
+      const bodyDoc = this.parser.parseFromString(
+        `<!DOCTYPE html><html><body>${reminderBody}</body></html>`,
+        'text/html'
+      );
+      bodyDoc.getElementById('reminderTab')?.remove();
+      bodyDoc.getElementById('mobileFloatingButton')?.remove();
+      reminderBody = bodyDoc.body ? bodyDoc.body.innerHTML : '';
+    }
 
     const reminderScripts = Array.from(reminderDoc.querySelectorAll('script'))
       .map((script) => script.outerHTML)

--- a/src/lib/utils/template-to-client-flow-converter.ts
+++ b/src/lib/utils/template-to-client-flow-converter.ts
@@ -1,0 +1,147 @@
+import { ClientFlowData } from '@/types';
+import { BaseTemplate } from '@/features/base-template/types';
+import { CleanTemplateResponse } from '@/types/template';
+
+/**
+ * Converts BaseTemplate to ClientFlowData format
+ * Used for base template previews without API calls.
+ * html_content is not stored in DB; caller must pass htmlContent (e.g. from builder_state_json conversion).
+ */
+export function convertBaseTemplateToClientFlowData(
+  template: BaseTemplate | CleanTemplateResponse,
+  htmlContent?: string | null
+): ClientFlowData | null {
+  if (!('id' in template) || !('template_id' in template)) {
+    return null;
+  }
+
+  const designJson = template.builder_state_json || {};
+  const devices = designJson.devices || [];
+  
+  // Default to desktop if no devices specified
+  const defaultDevices = devices.length > 0 
+    ? devices 
+    : [{ id: 1, device_type: 'desktop' }];
+
+  return {
+    template_id: 'template_id' in template ? template.template_id : (template as CleanTemplateResponse).id,
+    template_name: template.name,
+    template_description: template.description || '',
+    canvas_type: designJson.body?.canvas_type || 'single-row',
+    is_custom_coded: false,
+    is_generic: false, // Base templates are not generic by default
+    template_status: template.status,
+    template_created_at: template.created_at,
+    template_updated_at: template.updated_at,
+    template_created_by: 0,
+    template_updated_by: 0,
+    template_remarks: null,
+    staging_id: '',
+    builder_state_json: designJson,
+    template_html: htmlContent || '',
+    builder_state_json_client: designJson,
+    template_html_client: htmlContent || '',
+    reminder_tab_html: '',
+    reminder_tab_state_json: {},
+    reminder_tab_html_client: '',
+    reminder_tab_state_json_client: {},
+    review_status: '',
+    reviewed_by: null,
+    review_notes: null,
+    staging_status: '',
+    staging_created_at: '',
+    staging_updated_at: '',
+    account_mapping_id: 0,
+    account_id: 0,
+    account_mapping_created_at: '',
+    shoppers: [],
+    device_type_ids: defaultDevices.map((d: any) => d.id || 1),
+    devices: defaultDevices.map((d: any) => ({
+      id: d.id || 1,
+      device_type: d.device_type || 'desktop'
+    })),
+  };
+}
+
+/**
+ * Converts CleanTemplateResponse (from API) to ClientFlowData format
+ * Used when fetching template data via API
+ */
+export function convertCleanTemplateToClientFlowData(
+  templateResponse: CleanTemplateResponse,
+  htmlContent?: string | null
+): ClientFlowData | null {
+  if (!templateResponse.id) {
+    return null;
+  }
+
+  return {
+    template_id: templateResponse.id,
+    template_name: templateResponse.name,
+    template_description: templateResponse.description || '',
+    canvas_type: templateResponse.builder_state_json?.body?.canvas_type || 
+                  templateResponse.canvas_type || 
+                  'single-row',
+    is_custom_coded: templateResponse.is_custom_coded || false,
+    is_generic: templateResponse.is_generic || templateResponse.type === 'generic',
+    template_status: templateResponse.status,
+    template_created_at: templateResponse.createdAt.toISOString(),
+    template_updated_at: templateResponse.lastUpdated.toISOString(),
+    template_created_by: 0,
+    template_updated_by: 0,
+    template_remarks: null,
+    staging_id: '',
+    builder_state_json: templateResponse.builder_state_json || {},
+    template_html: htmlContent || '',
+    builder_state_json_client: templateResponse.builder_state_json_client || 
+                               templateResponse.builder_state_json || {},
+    template_html_client: htmlContent || '',
+    reminder_tab_html: templateResponse.reminder_tab_html || '',
+    reminder_tab_state_json: templateResponse.reminder_tab_state_json || {},
+    reminder_tab_html_client: templateResponse.reminder_tab_html_client || '',
+    reminder_tab_state_json_client: templateResponse.reminder_tab_state_json_client || {},
+    review_status: '',
+    reviewed_by: null,
+    review_notes: null,
+    staging_status: '',
+    staging_created_at: '',
+    staging_updated_at: '',
+    account_mapping_id: 0,
+    account_id: templateResponse.account_details?.id || 0,
+    account_mapping_created_at: '',
+    shoppers: [],
+    device_type_ids: templateResponse.device_ids || 
+                     templateResponse.devices?.map((d) => d.id) || [],
+    devices: templateResponse.devices?.map((d) => ({
+      id: d.id,
+      device_type: d.device_type || 'desktop'
+    })) || [],
+  };
+}
+
+/**
+ * Union type for template input sources
+ */
+export type TemplateSource = BaseTemplate | CleanTemplateResponse;
+
+/**
+ * Type guard to check if input is BaseTemplate
+ */
+function isBaseTemplate(template: TemplateSource): template is BaseTemplate {
+  return 'builder_state_json' in template && 'template_id' in template;
+}
+
+/**
+ * Universal converter that handles both BaseTemplate and CleanTemplateResponse
+ * Automatically detects the input type and converts accordingly
+ */
+export function convertTemplateToClientFlowData(
+  template: TemplateSource,
+  htmlContent?: string | null
+): ClientFlowData | null {
+  if (isBaseTemplate(template)) {
+    return convertBaseTemplateToClientFlowData(template, htmlContent);
+  } else {
+    return convertCleanTemplateToClientFlowData(template, htmlContent);
+  }
+}

--- a/src/lib/utils/templateFieldProcessor.ts
+++ b/src/lib/utils/templateFieldProcessor.ts
@@ -63,27 +63,20 @@ function processTextContent(
 ): { processedText: string; foundFieldIds: string[] } {
   const foundFieldIds: string[] = [];
   
-  console.log('🔤 Processing text:', text);
-  console.log('🔍 Regex pattern:', TEMPLATE_FIELD_REGEX);
   
   const processedText = text.replace(TEMPLATE_FIELD_REGEX, (match, fieldId) => {
-    console.log('🎯 Found match:', match, 'Field ID:', fieldId);
     const templateField = templateFieldsMap.get(fieldId);
     if (templateField) {
-      console.log('✅ Template field found:', templateField);
       foundFieldIds.push(fieldId);
       
       // Replace the placeholder with the default value and inject id attribute
       return injectIdIntoElement(templateField.default_field_value, fieldId);
     } else {
-      console.log('❌ No template field found for ID:', fieldId);
     }
     // Return the original placeholder if no matching field is found
     return match;
   });
 
-  console.log('📝 Processed text:', processedText);
-  console.log('🆔 Found field IDs:', foundFieldIds);
   return { processedText, foundFieldIds };
 }
 
@@ -227,25 +220,18 @@ export function processTemplateFields(
   design: UnlayerDesign,
   templateFields: CBTemplateFieldContentIdMapping[]
 ): UnlayerDesign {
-  console.log('🔄 Processing template fields...');
-  console.log('📊 Template fields count:', templateFields.length);
-  console.log('📋 Template fields:', templateFields);
   
   // Create a deep copy to avoid mutating the original object
   const processedDesign = JSON.parse(JSON.stringify(design)) as UnlayerDesign;
   
   // Create lookup map for efficient field access
   const templateFieldsMap = createTemplateFieldsMap(templateFields);
-  console.log('🗺️ Template fields map:', templateFieldsMap);
   
   // Extract field IDs first to see what we're looking for
   const foundFieldIds = extractTemplateFieldIds(processedDesign);
-  console.log('🔍 Found field IDs in design:', foundFieldIds);
   
   // Process all content in the design
   processDesignContent(processedDesign, templateFieldsMap);
-  
-  console.log('✅ Template fields processing completed');
   return processedDesign;
 }
 

--- a/src/stores/builder.store.ts
+++ b/src/stores/builder.store.ts
@@ -42,7 +42,6 @@ export const useBuilderStore = create<BuilderState & BuilderActions>()(
         setTemplateConfig: (config: TemplateConfig) => set({ templateConfig: config }),
         setCurrentTemplateId: (id: string | null) => set({ currentTemplateId: id }),
         setReminderTabConfig: (config: ReminderTabConfig) => {
-          console.log('🏪 Store: setReminderTabConfig called with:', config);
           set({ reminderTabConfig: config });
         },
         updateReminderTabConfig: (path: string, value: any) => {

--- a/src/stores/common/loading.store.ts
+++ b/src/stores/common/loading.store.ts
@@ -6,6 +6,8 @@ type LoadingState = {
   templateByIdLoading: boolean;
   devicesLoading: boolean;
   configSaving: boolean;
+  baseTemplateConfigCreation: boolean;
+  baseTemplateStatusUpdate: boolean;
   contentListingLoading: boolean;
   contentActionLoading: boolean;
   contentSubDataLoading: boolean;
@@ -23,6 +25,8 @@ type LoadingActions = {
     setTemplateByIdLoading: (loading: boolean) => void;
     setDevicesLoading: (loading: boolean) => void;
     setConfigSaving: (loading: boolean) => void;
+    setBaseTemplateConfigCreation: (loading: boolean) => void;
+    setBaseTemplateStatusUpdate: (loading: boolean) => void;
     setContentListingLoading: (loading: boolean) => void;
     setContentActionLoading: (loading: boolean) => void;
     setContentSubDataLoading: (loading: boolean) => void;
@@ -40,6 +44,8 @@ export const useLoadingStore = create<LoadingState & LoadingActions>((set) => ({
   templateByIdLoading: false,
   devicesLoading: false,
   configSaving: false,
+  baseTemplateConfigCreation: false,
+  baseTemplateStatusUpdate: false,
   contentListingLoading: false,
   contentActionLoading: false,
   contentSubDataLoading: false,
@@ -56,6 +62,10 @@ export const useLoadingStore = create<LoadingState & LoadingActions>((set) => ({
     setTemplateByIdLoading: (loading: boolean) => set({ templateByIdLoading: loading }),
     setDevicesLoading: (loading: boolean) => set({ devicesLoading: loading }),
     setConfigSaving: (loading: boolean) => set({ configSaving: loading }),
+    setBaseTemplateConfigCreation: (loading: boolean) =>
+      set({ baseTemplateConfigCreation: loading }),
+    setBaseTemplateStatusUpdate: (loading: boolean) =>
+      set({ baseTemplateStatusUpdate: loading }),
     setContentListingLoading: (loading: boolean) =>
       set({ contentListingLoading: loading }),
     setContentActionLoading: (loading: boolean) =>

--- a/src/stores/generic.store.ts
+++ b/src/stores/generic.store.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import type { AxiosInstance } from 'axios';
 import { ShopperType, AccountDetails } from '@/types/common';
 
 type GenericState = {
@@ -7,6 +8,7 @@ type GenericState = {
   accounts: AccountDetails[];
   authProvider: { userId: string; accountId: string; role: string };
   navigate: any;
+  apiClient: AxiosInstance | null;
   browserPreviewModalOpen: boolean;
 };
 
@@ -21,6 +23,7 @@ type GenericActions = {
       role: string;
     }) => void;
     setNavigate: (navigate: (path: string) => void) => void;
+    setApiClient: (apiClient: AxiosInstance | null) => void;
     setBrowserPreviewModalOpen: (open: boolean) => void;
   };
 };
@@ -31,6 +34,7 @@ export const useGenericStore = create<GenericState & GenericActions>((set) => ({
   accounts: [],
   authProvider: { userId: '', accountId: '', role: '' },
   navigate: null,
+  apiClient: null,
   browserPreviewModalOpen: false,
   actions: {
     setShoppers: (shoppers: ShopperType[]) => set({ shoppers }),
@@ -42,6 +46,7 @@ export const useGenericStore = create<GenericState & GenericActions>((set) => ({
       role: string;
     }) => set({ authProvider }),
     setNavigate: (navigate: (path: string) => void) => set({ navigate }),
+    setApiClient: (apiClient: AxiosInstance | null) => set({ apiClient }),
     setBrowserPreviewModalOpen: (open: boolean) => set({ browserPreviewModalOpen: open }),
   },
 }));

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -71,7 +71,8 @@ export interface TemplateConfig {
   description: string;
   status?: string;
   is_generic?: boolean;
-  account_ids?: number;
+  account_ids?: number[];
+  base_template_id?: string; // Optional base template selection
 }
 
 // Component Category Types


### PR DESCRIPTION
Major refactor and feature additions for base templates:

- APIs: remove debug logs and add base-template endpoints (getBaseTemplates, copyBaseTemplateToAccount, deleteBaseTemplate, updateBaseTemplateStatus). Extend getTemplatesForUI to accept params and allow unarchive to accept targetStatus.
- Components: move client-flow preview components into shared template-preview folder and update imports. Add BaseTemplateCard component to render template cards with preview modal, status dropdown, and preview conversion flow.
- Gallery & Page: replace in-list client filtering with server-side loading + debounced search; add BaseTemplateCardSkeleton and use server loading state. Wire loadTemplates and updateTemplateStatus into the gallery and use useSyncGenericContext to initialize shared context.
- Builder & Config: integrate loading store into BaseTemplateBuilder and BaseTemplateConfig, pass form from page to config, remove html_content prop usage, and improve step navigation and UX (loading states, responsive layout).
- Hooks & stores: refactor useBaseTemplateActions to pull apiClient from generic store, implement loadTemplates to call new API and transform responses, add useCallback and loading handling. Add device loading in gallery and use generic store API client where needed.
- Utilities: fix minor UI text and title changes and remove leftover console.logs across API methods.

These changes centralize preview components, enable server-side template listing and operations, improve loading UX, and prepare base-template management for backend-driven flows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple user-facing flows (base-template gallery, template creation, client editor) and introduces new backend-integrated operations (copy/delete/status), so regressions are possible if API response shapes or status semantics differ.
> 
> **Overview**
> **Base template management is moved from local/dummy data to backend-driven APIs and UI.** `TemplatesAPI` adds base-template listing, copy-to-account, delete, and status update endpoints, and `useBaseTemplateActions.loadTemplates` now calls the new `getBaseTemplates` API and normalizes the response into the app’s `BaseTemplate` model.
> 
> **The base-template gallery UI is refactored for server-side filtering/search and richer card interactions.** The gallery replaces client-side filtering with `onLoadTemplates` (debounced for search), adds skeleton loading, preloads devices once, and introduces `BaseTemplateCard` with inline status changes and an HTML-conversion-based preview modal.
> 
> **Template creation/editing flows are updated to use shared global context and support starting from a base template.** Builder/config hooks now pull `apiClient` from the generic store via `useSyncGenericContext`, `ConfigStep` adds an optional base-template selector, and `BuilderMain` can copy a base template into an account before applying user config.
> 
> **Client/editor and Unlayer UX is improved and debug noise removed.** Preview components are centralized under `components/common/template-preview`, Unlayer editor is constrained to supported devices via `useUnlayerDeviceOptions`, client editing auto-selects the first block and hides the Popup tab, and numerous `console.log`s/props plumbing (e.g., passing `apiClient`) are removed/simplified.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67fa313d3d28b2bbcc6957585de3770880696b4e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->