### PR TITLE
Add custom components system and preview fixes

### DIFF
--- a/src/api/services/ContentAPI.ts
+++ b/src/api/services/ContentAPI.ts
@@ -110,8 +110,8 @@ export class ContentAPI extends BaseAPI {
 
   async getShopperDetails(payload: GetShopperDetailsPayload): Promise<ShopperDetails> {
     try {
-      const response = await this.post<ShopperDetails>(`/shopper-group-details/description`, payload, true);
-      return response;
+      const response = await this.post<ShopperDetails[]>(`/shopper-group-details/description`, payload, true);
+      return response[0];
     } catch (error) {
       throw error;
     }

--- a/src/components/common/template-preview/BrowserPreviewModal.tsx
+++ b/src/components/common/template-preview/BrowserPreviewModal.tsx
@@ -18,6 +18,9 @@ export const BrowserPreviewModal: React.FC<BrowserPreviewModalProps> = ({
   websiteBackground,
   popupTemplate,
 }) => {
+  const templateId = Array.isArray(popupTemplate) && popupTemplate[0]?.template_id != null
+    ? String(popupTemplate[0].template_id)
+    : 'none';
   return (
     <Modal
       title={`${viewport === 'desktop' ? 'Desktop' : 'Mobile'} Preview`}
@@ -26,10 +29,11 @@ export const BrowserPreviewModal: React.FC<BrowserPreviewModalProps> = ({
       footer={null}
       width={viewport === 'desktop' ? 1400 : 600}
       centered
-      destroyOnHidden
+      destroyOnClose
     >
       <div className="py-4">
         <BrowserPreview
+          key={`${viewport}-${templateId}`}
           className="shadow-md"
           viewport={viewport}
           websiteBackground={websiteBackground}

--- a/src/custom-components/components/ActiveComponentsList.tsx
+++ b/src/custom-components/components/ActiveComponentsList.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import type { DetectedComponent } from '../utils/detection';
+
+export interface ActiveComponentsListProps {
+  components: DetectedComponent[];
+  selectedComponent: DetectedComponent | null;
+  onSelect: (comp: DetectedComponent) => void;
+}
+
+export const ActiveComponentsList: React.FC<ActiveComponentsListProps> = ({
+  components,
+  selectedComponent,
+  onSelect,
+}) => {
+  if (components.length === 0) return null;
+
+  return (
+    <div style={{ padding: '8px', minWidth: '200px' }}>
+      <div
+        style={{
+          fontSize: '11px',
+          fontWeight: 700,
+          color: '#6B7280',
+          textTransform: 'uppercase',
+          letterSpacing: '0.5px',
+          marginBottom: '8px',
+        }}
+      >
+        Components in design
+      </div>
+      {components.map((comp) => (
+        <button
+          type="button"
+          key={comp.htmlBlockId}
+          onClick={() => onSelect(comp)}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '8px',
+            padding: '8px 12px',
+            border:
+              selectedComponent?.htmlBlockId === comp.htmlBlockId
+                ? '2px solid #6366F1'
+                : '1px solid #E5E7EB',
+            borderRadius: '6px',
+            background: 'white',
+            cursor: 'pointer',
+            width: '100%',
+            marginBottom: '4px',
+            textAlign: 'left',
+          }}
+        >
+          <span>{comp.componentDef.icon}</span>
+          <span style={{ fontSize: '13px', fontWeight: 500 }}>{comp.componentDef.name}</span>
+        </button>
+      ))}
+    </div>
+  );
+};

--- a/src/custom-components/components/ComponentGallery.tsx
+++ b/src/custom-components/components/ComponentGallery.tsx
@@ -1,0 +1,164 @@
+import React, { useState } from 'react';
+import { getAllComponents, type CustomComponentDefinition } from '../registry';
+
+export interface ComponentGalleryProps {
+  onUseComponent: (componentId: string) => void;
+  isOpen: boolean;
+  onToggle: () => void;
+  /** When false, no floating trigger button is rendered when closed (parent provides its own trigger, e.g. beside Save) */
+  renderTriggerButton?: boolean;
+}
+
+export const ComponentGallery: React.FC<ComponentGalleryProps> = ({
+  onUseComponent,
+  isOpen,
+  onToggle,
+  renderTriggerButton = true,
+}) => {
+  const components = getAllComponents();
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+
+  const handleUse = (comp: CustomComponentDefinition) => {
+    const html = comp.render(comp.defaultProps as Record<string, unknown>);
+    navigator.clipboard.writeText(html).then(() => {
+      setCopiedId(comp.id);
+      setTimeout(() => setCopiedId(null), 2000);
+    });
+    onUseComponent(comp.id);
+  };
+
+  if (!isOpen) {
+    if (!renderTriggerButton) return null;
+    return (
+      <button
+        type="button"
+        onClick={onToggle}
+        style={{
+          position: 'fixed',
+          top: '12px',
+          left: '12px',
+          zIndex: 10000,
+          padding: '8px 16px',
+          background: '#6366F1',
+          color: 'white',
+          border: 'none',
+          borderRadius: '6px',
+          cursor: 'pointer',
+          fontSize: '13px',
+          fontWeight: 600,
+          boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
+        }}
+      >
+        🧩 Components
+      </button>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        width: '320px',
+        height: '100vh',
+        background: '#FFFFFF',
+        borderRight: '1px solid #E5E7EB',
+        zIndex: 10000,
+        overflowY: 'auto',
+        boxShadow: '4px 0 16px rgba(0,0,0,0.1)',
+        fontFamily: 'Arial, sans-serif',
+      }}
+    >
+      <div
+        style={{
+          padding: '16px',
+          borderBottom: '1px solid #E5E7EB',
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <h3 style={{ margin: 0, fontSize: '16px', fontWeight: 700 }}>🧩 Custom Components</h3>
+        <button
+          type="button"
+          onClick={onToggle}
+          style={{
+            background: 'none',
+            border: 'none',
+            fontSize: '20px',
+            cursor: 'pointer',
+            color: '#6B7280',
+          }}
+        >
+          ✕
+        </button>
+      </div>
+
+      <div style={{ padding: '12px' }}>
+        {components.map((comp) => (
+          <div
+            key={comp.id}
+            style={{
+              border: '1px solid #E5E7EB',
+              borderRadius: '8px',
+              marginBottom: '12px',
+              overflow: 'hidden',
+            }}
+          >
+            <div
+              style={{
+                padding: '12px',
+                background: '#F9FAFB',
+                borderBottom: '1px solid #E5E7EB',
+                maxHeight: '150px',
+                overflow: 'hidden',
+                transform: 'scale(0.85)',
+                transformOrigin: 'top left',
+              }}
+              dangerouslySetInnerHTML={{
+                __html: comp.render(comp.defaultProps as Record<string, unknown>),
+              }}
+            />
+
+            <div style={{ padding: '12px' }}>
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '6px',
+                  marginBottom: '4px',
+                }}
+              >
+                <span style={{ fontSize: '18px' }}>{comp.icon}</span>
+                <strong style={{ fontSize: '14px' }}>{comp.name}</strong>
+              </div>
+              <p style={{ margin: '0 0 8px', fontSize: '12px', color: '#6B7280' }}>
+                {comp.description}
+              </p>
+              <div style={{ display: 'flex', gap: '8px' }}>
+                <button
+                  type="button"
+                  onClick={() => handleUse(comp)}
+                  style={{
+                    flex: 1,
+                    padding: '6px 12px',
+                    background: '#6366F1',
+                    color: 'white',
+                    border: 'none',
+                    borderRadius: '4px',
+                    cursor: 'pointer',
+                    fontSize: '12px',
+                    fontWeight: 600,
+                  }}
+                >
+                  {copiedId === comp.id ? '✓ Copied HTML' : '+ Add to Design'}
+                </button>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/custom-components/components/OverlayPropertyPanel.tsx
+++ b/src/custom-components/components/OverlayPropertyPanel.tsx
@@ -1,0 +1,310 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import type { DetectedComponent } from '../utils/detection';
+import type { ComponentPropSchema } from '../registry';
+
+export interface OverlayPropertyPanelProps {
+  component: DetectedComponent;
+  onPropsChange: (componentId: string, htmlBlockId: string, newProps: Record<string, unknown>) => void;
+  onClose: () => void;
+  userRole: 'admin' | 'client';
+  editorContainerRef?: React.RefObject<HTMLDivElement | null>;
+  /** 'overlay' = right-side overlay; 'left' = left-side overlay; 'inline' = card in flow below header */
+  placement?: 'overlay' | 'left' | 'inline';
+}
+
+export const OverlayPropertyPanel: React.FC<OverlayPropertyPanelProps> = ({
+  component,
+  onPropsChange,
+  onClose,
+  userRole,
+  placement = 'overlay',
+}) => {
+  const [localProps, setLocalProps] = useState<Record<string, unknown>>(component.currentProps);
+
+  useEffect(() => {
+    setLocalProps(component.currentProps);
+  }, [component.htmlBlockId, component.currentProps]);
+
+  const handlePropChange = useCallback(
+    (propName: string, value: unknown) => {
+      const newProps = { ...localProps, [propName]: value };
+      setLocalProps(newProps);
+      onPropsChange(component.componentId, component.htmlBlockId, newProps);
+    },
+    [localProps, component, onPropsChange]
+  );
+
+  const renderPropEditor = (schema: ComponentPropSchema) => {
+    const value = (localProps[schema.name] ?? schema.defaultValue) as string | number | boolean;
+
+    switch (schema.type) {
+      case 'number':
+        return (
+          <input
+            type="number"
+            value={Number(value)}
+            min={schema.min}
+            max={schema.max}
+            step={schema.step ?? 1}
+            onChange={(e) => handlePropChange(schema.name, Number(e.target.value))}
+            style={{
+              width: '100%',
+              padding: '6px 8px',
+              border: '1px solid #D1D5DB',
+              borderRadius: '4px',
+              fontSize: '13px',
+            }}
+          />
+        );
+
+      case 'text':
+        return (
+          <input
+            type="text"
+            value={String(value)}
+            onChange={(e) => handlePropChange(schema.name, e.target.value)}
+            style={{
+              width: '100%',
+              padding: '6px 8px',
+              border: '1px solid #D1D5DB',
+              borderRadius: '4px',
+              fontSize: '13px',
+            }}
+          />
+        );
+
+      case 'color':
+        return (
+          <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+            <input
+              type="color"
+              value={String(value)}
+              onChange={(e) => handlePropChange(schema.name, e.target.value)}
+              style={{ width: '36px', height: '30px', border: 'none', cursor: 'pointer' }}
+            />
+            <input
+              type="text"
+              value={String(value)}
+              onChange={(e) => handlePropChange(schema.name, e.target.value)}
+              style={{
+                flex: 1,
+                padding: '6px 8px',
+                border: '1px solid #D1D5DB',
+                borderRadius: '4px',
+                fontSize: '12px',
+                fontFamily: 'monospace',
+              }}
+            />
+          </div>
+        );
+
+      case 'select':
+        return (
+          <select
+            value={String(value)}
+            onChange={(e) => handlePropChange(schema.name, e.target.value)}
+            style={{
+              width: '100%',
+              padding: '6px 8px',
+              border: '1px solid #D1D5DB',
+              borderRadius: '4px',
+              fontSize: '13px',
+            }}
+          >
+            {schema.options?.map((opt) => (
+              <option key={String(opt.value)} value={String(opt.value)}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        );
+
+      case 'toggle':
+        return (
+          <label style={{ display: 'flex', alignItems: 'center', gap: '8px', cursor: 'pointer' }}>
+            <input
+              type="checkbox"
+              checked={!!value}
+              onChange={(e) => handlePropChange(schema.name, e.target.checked)}
+            />
+            <span style={{ fontSize: '13px' }}>{value ? 'Enabled' : 'Disabled'}</span>
+          </label>
+        );
+
+      case 'range':
+        return (
+          <div>
+            <input
+              type="range"
+              value={Number(value)}
+              min={schema.min ?? 0}
+              max={schema.max ?? 100}
+              step={schema.step ?? 1}
+              onChange={(e) => handlePropChange(schema.name, Number(e.target.value))}
+              style={{ width: '100%' }}
+            />
+            <span style={{ fontSize: '12px', color: '#6B7280' }}>{value}</span>
+          </div>
+        );
+
+      default:
+        return null;
+    }
+  };
+
+  const isInline = placement === 'inline';
+  const isLeft = placement === 'left';
+  return (
+    <div
+      style={{
+        ...(isInline
+          ? {
+              width: '100%',
+              maxWidth: '720px',
+              maxHeight: '70vh',
+              minHeight: '280px',
+              marginBottom: '16px',
+              background: '#FFFFFF',
+              border: '1px solid #E5E7EB',
+              borderRadius: '8px',
+              display: 'flex',
+              flexDirection: 'column',
+              boxShadow: '0 1px 3px rgba(0,0,0,0.06)',
+              overflow: 'hidden',
+            }
+          : {
+              position: 'absolute',
+              top: 0,
+              ...(isLeft ? { left: 0 } : { right: 0 }),
+              width: '360px',
+              height: '100%',
+              background: '#FFFFFF',
+              zIndex: 9999,
+              ...(isLeft
+                ? { borderRight: '1px solid #E5E7EB', boxShadow: '4px 0 16px rgba(0,0,0,0.08)' }
+                : { borderLeft: '1px solid #E5E7EB', boxShadow: '-4px 0 16px rgba(0,0,0,0.08)' }),
+              display: 'flex',
+              flexDirection: 'column',
+            }),
+      }}
+    >
+      <div
+        style={{
+          padding: '14px 16px',
+          borderBottom: '1px solid #E5E7EB',
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          background: '#F9FAFB',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <span style={{ fontSize: '20px' }}>{component.componentDef.icon}</span>
+          <strong style={{ fontSize: '14px' }}>{component.componentDef.name}</strong>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          style={{
+            background: 'none',
+            border: 'none',
+            fontSize: '18px',
+            cursor: 'pointer',
+            color: '#6B7280',
+            padding: '4px',
+          }}
+        >
+          ✕
+        </button>
+      </div>
+
+      <div
+        style={{
+          padding: '12px 16px',
+          borderBottom: '1px solid #E5E7EB',
+          background: '#F9FAFB',
+        }}
+      >
+        <div
+          style={{
+            transform: 'scale(0.75)',
+            transformOrigin: 'top center',
+            maxHeight: '120px',
+            overflow: 'hidden',
+          }}
+          dangerouslySetInnerHTML={{
+            __html: component.componentDef.render(localProps),
+          }}
+        />
+      </div>
+
+      <div
+        style={{
+          flex: 1,
+          overflowY: 'auto',
+          padding: '16px',
+        }}
+      >
+        <div
+          style={{
+            fontSize: '11px',
+            fontWeight: 700,
+            color: '#6B7280',
+            textTransform: 'uppercase',
+            letterSpacing: '0.5px',
+            marginBottom: '12px',
+          }}
+        >
+          Properties
+        </div>
+
+        {component.componentDef.props.map((propSchema) => (
+          <div key={propSchema.name} style={{ marginBottom: '14px' }}>
+            <label
+              style={{
+                display: 'block',
+                fontSize: '12px',
+                fontWeight: 600,
+                color: '#374151',
+                marginBottom: '4px',
+              }}
+            >
+              {propSchema.label}
+            </label>
+            {renderPropEditor(propSchema)}
+          </div>
+        ))}
+      </div>
+
+      {userRole === 'admin' && (
+        <div
+          style={{
+            padding: '8px 16px',
+            borderTop: '1px solid #E5E7EB',
+            background: '#F9FAFB',
+          }}
+        >
+          <details>
+            <summary style={{ fontSize: '11px', color: '#9CA3AF', cursor: 'pointer' }}>
+              View Generated HTML
+            </summary>
+            <pre
+              style={{
+                fontSize: '10px',
+                background: '#1F2937',
+                color: '#10B981',
+                padding: '8px',
+                borderRadius: '4px',
+                overflow: 'auto',
+                maxHeight: '150px',
+                marginTop: '4px',
+              }}
+            >
+              {component.componentDef.render(localProps)}
+            </pre>
+          </details>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/custom-components/definitions/product-carousel.ts
+++ b/src/custom-components/definitions/product-carousel.ts
@@ -1,0 +1,256 @@
+import { registerComponent } from '../registry';
+
+function escapePropsForAttribute(props: Record<string, unknown>): string {
+  return JSON.stringify(props).replace(/'/g, "\\'");
+}
+
+interface ProductItem {
+  title?: string;
+  price?: string;
+  size?: string;
+  imageUrl?: string;
+  link?: string;
+}
+
+function renderProductCarousel(props: Record<string, unknown>): string {
+  const {
+    title = 'Recently viewed products',
+    products = [
+      { title: 'Sensitive Skin Balm', price: '$16.50', size: '120g', imageUrl: '', link: '#' },
+      { title: 'Cream Conditioner', price: '$14.50', size: '', imageUrl: '', link: '#' },
+    ],
+    cardBgColor = '#FFFFFF',
+    containerBgColor = '#F5F5F5',
+    textColor = '#1F2937',
+    priceColor = '#1F2937',
+    subtextColor = '#6B7280',
+    accentColor = '#4285F4',
+    buttonText = 'ADD TO CART',
+    cardBorderRadius = 12,
+    showArrows = true,
+    showDots = true,
+  } = props as Record<string, string | number | boolean | ProductItem[]>;
+
+  const items = Array.isArray(products) ? products : [];
+  const radius = Number(cardBorderRadius) || 12;
+  const arrows = showArrows !== false;
+  const dots = showDots !== false;
+
+  // Each card is a self-contained product card with data attributes for JS targeting
+  const productCards = items
+    .slice(0, 10)
+    .map(
+      (p: ProductItem, i: number) => `
+      <div
+        id="pcar-card-${i}"
+        class="pcar-card"
+        data-index="${i}"
+        data-product-title="${String(p.title || '')}"
+        style="flex:0 0 auto; width:240px; background:${cardBgColor}; border-radius:${radius}px; overflow:hidden; border:1px solid #E8E8E8; scroll-snap-align:start; display:flex; flex-direction:column;"
+      >
+        <!-- Product image slot -->
+        <div
+          id="pcar-card-${i}-img"
+          class="pcar-card-img"
+          data-field="image"
+          data-slot="product-image"
+          style="width:100%; height:160px; background:#F3F4F6; display:flex; align-items:center; justify-content:center; overflow:hidden;"
+        >
+          ${
+            p.imageUrl
+              ? `<img src="${String(p.imageUrl)}" alt="${String(p.title || 'Product')}" style="width:100%; height:100%; object-fit:cover; display:block;" />`
+              : `<svg width="48" height="48" viewBox="0 0 24 24" fill="none" style="opacity:0.3;">
+                  <rect x="3" y="3" width="18" height="18" rx="2" stroke="#9CA3AF" stroke-width="1.5"/>
+                  <circle cx="8.5" cy="8.5" r="2" stroke="#9CA3AF" stroke-width="1.5"/>
+                  <path d="M3 16l5-5 4 4 3-3 6 6" stroke="#9CA3AF" stroke-width="1.5" stroke-linecap="round"/>
+                </svg>`
+          }
+        </div>
+
+        <!-- Card body — flex column so button always sits at bottom regardless of subtitle -->
+        <div
+          id="pcar-card-${i}-body"
+          class="pcar-card-body"
+          data-field="body"
+          style="padding:14px 16px; display:flex; flex-direction:column; flex:1;"
+        >
+          <p
+            id="pcar-card-${i}-title"
+            class="pcar-card-title"
+            data-field="title"
+            style="margin:0 0 4px; color:${textColor}; font-size:14px; font-weight:600; line-height:1.3; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;"
+          >${String(p.title || 'Product Name')}</p>
+
+          <!-- Subtitle — always rendered with min-height to keep cards equal -->
+          <p
+            id="pcar-card-${i}-size"
+            class="pcar-card-size"
+            data-field="size"
+            style="margin:0 0 6px; color:${subtextColor}; font-size:12px; line-height:1.3; min-height:16px;"
+          >${p.size ? String(p.size) : ''}</p>
+
+          <p
+            id="pcar-card-${i}-price"
+            class="pcar-card-price"
+            data-field="price"
+            style="margin:0; color:${priceColor}; font-size:15px; font-weight:700;"
+          >${String(p.price || '')}</p>
+
+          <!-- Spacer pushes button to bottom -->
+          <div style="flex:1; min-height:8px;"></div>
+
+          <a
+            id="pcar-card-${i}-btn"
+            class="pcar-card-btn"
+            data-field="cta"
+            href="${String(p.link || '#')}"
+            style="display:block; background:${accentColor}; color:#fff; padding:10px 16px; border-radius:8px; font-size:12px; font-weight:700; text-align:center; text-decoration:none; letter-spacing:0.03em;"
+          >${String(buttonText)}</a>
+        </div>
+      </div>`
+    )
+    .join('');
+
+  // Dot indicators — only render when there are more cards than typically visible (>2)
+  // With 240px cards + 12px gap in ~480px+ container, ~2 cards are visible at once
+  const dotsHtml = dots && items.length > 2
+    ? items.slice(0, 10).map((_, i) =>
+        `<span
+          id="pcar-dot-${i}"
+          class="pcar-dot"
+          data-dot-index="${i}"
+          style="width:8px; height:8px; border-radius:50%; background:${i === 0 ? accentColor : '#D1D5DB'}; transition:background 0.2s; cursor:pointer;"
+        ></span>`
+      ).join('')
+    : '';
+
+  const html = `
+    <style>
+      .pcar-root { box-sizing: border-box; max-width: 100%; }
+      .pcar-root * { box-sizing: border-box; }
+      .pcar-track {
+        scroll-snap-type: x mandatory;
+        -webkit-overflow-scrolling: touch;
+        scrollbar-width: none;
+      }
+      .pcar-track::-webkit-scrollbar { display: none; }
+      .pcar-card { scroll-snap-align: start; transition: transform 0.15s ease; }
+      .pcar-arrow {
+        width: 36px; height: 36px; border-radius: 50%;
+        background: #1F2937; color: #fff; border: none;
+        display: flex; align-items: center; justify-content: center;
+        cursor: pointer; flex-shrink: 0; font-size: 18px;
+        transition: opacity 0.15s;
+      }
+      .pcar-arrow:hover { opacity: 0.8; }
+      @media (max-width: 480px) {
+        .pcar-card { width: 200px !important; }
+        .pcar-card-img { height: 120px !important; }
+        .pcar-arrow { width: 30px; height: 30px; font-size: 14px; }
+      }
+    </style>
+    <div
+      data-component="product-carousel"
+      data-props='${escapePropsForAttribute(props as Record<string, unknown>)}'
+      data-card-count="${items.length}"
+      id="pcar-root"
+      class="pcar-root"
+      style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; background:${containerBgColor}; padding:20px; border-radius:16px; max-width:100%;"
+    >
+      <!-- Section title -->
+      <h3
+        id="pcar-title"
+        data-field="title"
+        style="margin:0 0 16px; color:${textColor}; font-size:16px; font-weight:700;"
+      >${String(title)}</h3>
+
+      <!-- Carousel navigation row -->
+      <div
+        id="pcar-nav"
+        data-field="nav-row"
+        style="display:flex; align-items:center; gap:10px;"
+      >
+        ${arrows ? `
+        <div
+          id="pcar-prev"
+          class="pcar-arrow"
+          data-action="prev"
+          role="button"
+          aria-label="Previous products"
+          tabindex="0"
+        >&#8249;</div>` : ''}
+
+        <!-- Scrollable track — this is the slot where JS will inject/manage cards -->
+        <div
+          id="pcar-track"
+          class="pcar-track"
+          data-slot="product-cards"
+          data-field="track"
+          role="list"
+          aria-label="Product carousel"
+          style="display:flex; overflow-x:auto; gap:12px; padding:4px 2px; flex:1; min-width:0;"
+        >
+          ${productCards || `
+          <div
+            id="pcar-empty"
+            data-field="empty-state"
+            style="color:#9CA3AF; font-size:13px; padding:40px 16px; text-align:center; width:100%;"
+          >Products will appear here</div>`}
+        </div>
+
+        ${arrows ? `
+        <div
+          id="pcar-next"
+          class="pcar-arrow"
+          data-action="next"
+          role="button"
+          aria-label="Next products"
+          tabindex="0"
+        >&#8250;</div>` : ''}
+      </div>
+
+      <!-- Dot indicators -->
+      ${dotsHtml ? `
+      <div
+        id="pcar-dots"
+        data-field="dots"
+        data-slot="carousel-dots"
+        style="display:flex; justify-content:center; gap:6px; margin-top:14px;"
+      >${dotsHtml}</div>` : ''}
+    </div>
+  `;
+  return html.trim();
+}
+
+registerComponent({
+  id: 'product-carousel',
+  name: 'Product Carousel',
+  description: 'Horizontal scrollable product cards with navigation',
+  category: 'commerce',
+  icon: '🛒',
+  props: [
+    { name: 'title', label: 'Section Title', type: 'text', defaultValue: 'Recently viewed products' },
+    { name: 'containerBgColor', label: 'Container Background', type: 'color', defaultValue: '#F5F5F5' },
+    { name: 'cardBgColor', label: 'Card Background', type: 'color', defaultValue: '#FFFFFF' },
+    { name: 'textColor', label: 'Text Color', type: 'color', defaultValue: '#1F2937' },
+    { name: 'priceColor', label: 'Price Color', type: 'color', defaultValue: '#1F2937' },
+    { name: 'subtextColor', label: 'Subtext Color', type: 'color', defaultValue: '#6B7280' },
+    { name: 'accentColor', label: 'Button Color', type: 'color', defaultValue: '#4285F4' },
+    { name: 'buttonText', label: 'Button Text', type: 'text', defaultValue: 'ADD TO CART' },
+  ],
+  defaultProps: {
+    title: 'Recently viewed products',
+    products: [
+      { title: 'Sensitive Skin Balm', price: '$16.50', size: '120g', imageUrl: '', link: '#' },
+      { title: 'Cream Conditioner', price: '$14.50', size: '', imageUrl: '', link: '#' },
+    ],
+    containerBgColor: '#F5F5F5',
+    cardBgColor: '#FFFFFF',
+    textColor: '#1F2937',
+    priceColor: '#1F2937',
+    subtextColor: '#6B7280',
+    accentColor: '#4285F4',
+    buttonText: 'ADD TO CART',
+  },
+  render: renderProductCarousel,
+});

--- a/src/custom-components/definitions/two-column-coupon-list.ts
+++ b/src/custom-components/definitions/two-column-coupon-list.ts
@@ -1,0 +1,161 @@
+import { registerComponent } from '../registry';
+
+function escapePropsForAttribute(props: Record<string, unknown>): string {
+  return JSON.stringify(props).replace(/'/g, "\\'");
+}
+
+interface CouponItem {
+  offerText?: string;
+  subtext?: string;
+  code?: string;
+  label?: string;
+}
+
+function renderTwoColumnCouponList(props: Record<string, unknown>): string {
+  const {
+    coupons = [
+      { offerText: '10% Off', subtext: 'Ongoing Offer' },
+    ],
+    title = '',
+    buttonColor = '#DC2626',
+    buttonTextColor = '#FFFFFF',
+    bgColor = '#FFFFFF',
+    textColor = '#1F2937',
+    subtextColor = '#6B7280',
+    buttonLabel = 'SAVE',
+    dividerColor = '#F3F4F6',
+    itemPaddingV = 14,
+    itemPaddingH = 0,
+  } = props as Record<string, string | number | CouponItem[]>;
+
+  const items = Array.isArray(coupons) ? coupons : [];
+  const safeTitle = String(title || '');
+  const padV = Number(itemPaddingV) || 14;
+  const padH = Number(itemPaddingH) || 0;
+
+  const couponRows = items
+    .slice(0, 12)
+    .map((c: CouponItem, i: number) => {
+      const offer = String(c.offerText ?? c.code ?? 'Offer');
+      const sub = String(c.subtext ?? c.label ?? '');
+      const isLast = i === Math.min(items.length, 12) - 1;
+
+      return `
+      <div
+        id="tcl-item-${i}"
+        class="tcl-item"
+        data-index="${i}"
+        data-offer="${offer}"
+        data-slot="coupon-item"
+        style="display:flex; align-items:center; justify-content:space-between; gap:12px; padding:${padV}px ${padH}px;${!isLast ? ` border-bottom:1px solid ${dividerColor};` : ''} box-sizing:border-box;"
+      >
+        <!-- Offer text -->
+        <div
+          id="tcl-item-${i}-text"
+          class="tcl-item-text"
+          data-field="text-block"
+          style="flex:1; min-width:0;"
+        >
+          <div
+            id="tcl-item-${i}-offer"
+            class="tcl-item-offer"
+            data-field="offer"
+            style="font-weight:700; font-size:16px; color:${textColor}; line-height:1.3;"
+          >${offer}</div>
+          ${sub ? `
+          <div
+            id="tcl-item-${i}-sub"
+            class="tcl-item-sub"
+            data-field="subtext"
+            style="font-size:13px; color:${subtextColor}; font-weight:400; margin-top:2px; line-height:1.3;"
+          >${sub}</div>` : ''}
+        </div>
+
+        <!-- Action button -->
+        <a
+          id="tcl-item-${i}-btn"
+          class="tcl-btn"
+          data-field="cta"
+          data-action="save-coupon"
+          data-coupon-index="${i}"
+          href="#"
+          style="flex-shrink:0; background:${buttonColor}; color:${buttonTextColor}; border:none; padding:10px 22px; border-radius:8px; font-size:13px; font-weight:700; text-align:center; text-decoration:none; letter-spacing:0.02em; line-height:1;"
+        >${String(buttonLabel)}</a>
+      </div>`;
+    })
+    .join('');
+
+  const html = `
+    <style>
+      .tcl-root { box-sizing: border-box; max-width: 100%; }
+      .tcl-root * { box-sizing: border-box; }
+      @media (max-width: 480px) {
+        .tcl-item { flex-wrap: wrap !important; }
+        .tcl-btn { margin-top: 8px; width: 100% !important; }
+      }
+    </style>
+    <div
+      data-component="two-column-coupon-list"
+      data-props='${escapePropsForAttribute(props as Record<string, unknown>)}'
+      data-coupon-count="${items.length}"
+      id="tcl-root"
+      class="tcl-root"
+      style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; background:${bgColor}; padding:16px; box-sizing:border-box; max-width:100%;"
+    >
+      ${safeTitle ? `
+      <h3
+        id="tcl-title"
+        data-field="title"
+        style="margin:0 0 12px; color:${textColor}; font-size:16px; font-weight:700;"
+      >${safeTitle}</h3>` : ''}
+
+      <!-- Coupon list — JS can append/replace items inside this slot -->
+      <div
+        id="tcl-list"
+        class="tcl-list"
+        data-slot="coupon-items"
+        role="list"
+      >
+        ${couponRows || `
+        <div
+          id="tcl-empty"
+          data-field="empty-state"
+          style="color:#9CA3AF; font-size:13px; padding:20px 0; text-align:center;"
+        >Coupons will appear here</div>`}
+      </div>
+    </div>
+  `;
+  return html.trim();
+}
+
+registerComponent({
+  id: 'two-column-coupon-list',
+  name: 'Two-Column Coupon List',
+  description: 'List of offers with action buttons',
+  category: 'commerce',
+  icon: '🎟️',
+  props: [
+    { name: 'title', label: 'Section Title', type: 'text', defaultValue: '' },
+    { name: 'buttonColor', label: 'Button Color', type: 'color', defaultValue: '#DC2626' },
+    { name: 'buttonTextColor', label: 'Button Text Color', type: 'color', defaultValue: '#FFFFFF' },
+    { name: 'bgColor', label: 'Background', type: 'color', defaultValue: '#FFFFFF' },
+    { name: 'textColor', label: 'Offer Text Color', type: 'color', defaultValue: '#1F2937' },
+    { name: 'subtextColor', label: 'Subtext Color', type: 'color', defaultValue: '#6B7280' },
+    { name: 'dividerColor', label: 'Divider Color', type: 'color', defaultValue: '#F3F4F6' },
+    { name: 'buttonLabel', label: 'Button Label', type: 'text', defaultValue: 'SAVE' },
+  ],
+  defaultProps: {
+    title: '',
+    coupons: [
+      { offerText: '10% Off', subtext: 'Ongoing Offer' },
+    ],
+    buttonColor: '#DC2626',
+    buttonTextColor: '#FFFFFF',
+    bgColor: '#FFFFFF',
+    textColor: '#1F2937',
+    subtextColor: '#6B7280',
+    dividerColor: '#F3F4F6',
+    buttonLabel: 'SAVE',
+  },
+  render: renderTwoColumnCouponList,
+});

--- a/src/custom-components/definitions/wishlist-progress-bar.ts
+++ b/src/custom-components/definitions/wishlist-progress-bar.ts
@@ -1,0 +1,168 @@
+import { registerComponent } from '../registry';
+
+function escapePropsForAttribute(props: Record<string, unknown>): string {
+  return JSON.stringify(props).replace(/'/g, "\\'");
+}
+
+function renderWishlistProgressBar(props: Record<string, unknown>): string {
+  const {
+    currentAmount = 390,
+    targetAmount = 530,
+    discountText = '10% OFF',
+    barColor = '#4285F4',
+    trackColor = '#E0E0E0',
+    bgColor = '#FFFFFF',
+    textColor = '#1F2937',
+    secondaryTextColor = '#6B7280',
+    currency = '$',
+    unlockLabel = 'savings',
+    footerText = '',
+  } = props as Record<string, number | string>;
+
+  const current = Number(currentAmount);
+  const target = Number(targetAmount);
+  const remaining = Math.max(0, target - current);
+  const percent = target > 0 ? Math.min((current / target) * 100, 100) : 0;
+  // Clamp the pill so it never overlaps the end circle (reserve ~60px for it)
+  // The bar itself stops short of the circle, so pill % is relative to bar width
+  const clampedPercent = Math.min(percent, 100);
+
+  const html = `
+    <style>
+      .wpb-root { box-sizing: border-box; max-width: 100%; }
+      .wpb-root * { box-sizing: border-box; }
+      @media (max-width: 480px) {
+        .wpb-root { padding: 16px !important; }
+        .wpb-head { font-size: 14px !important; }
+        .wpb-pill { font-size: 12px !important; padding: 4px 10px !important; }
+        .wpb-circle { width: 44px !important; height: 44px !important; }
+        .wpb-circle-text { font-size: 9px !important; }
+      }
+    </style>
+    <div
+      data-component="wishlist-progress-bar"
+      data-props='${escapePropsForAttribute(props as Record<string, unknown>)}'
+      id="wpb-root"
+      class="wpb-root"
+      style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; background:${bgColor}; padding:16px; border-radius:12px; max-width:100%;"
+    >
+      <!-- Heading -->
+      <p
+        id="wpb-head"
+        data-field="heading"
+        class="wpb-head"
+        style="margin:0 0 20px; color:${textColor}; font-size:15px; font-weight:600; text-align:center;"
+      >Add ${currency}${remaining} more to unlock ${String(unlockLabel)}</p>
+
+      <!-- Progress row: bar + circle side by side -->
+      <div
+        id="wpb-progress"
+        data-field="progress-row"
+        style="display:flex; align-items:center; gap:14px;"
+      >
+        <!-- Bar section (takes remaining space) -->
+        <div
+          id="wpb-bar-section"
+          data-field="bar-section"
+          style="flex:1; min-width:0; position:relative; padding-top:36px; padding-bottom:24px;"
+        >
+          <!-- Floating pill indicator -->
+          <div
+            id="wpb-pill-wrap"
+            data-field="pill"
+            style="position:absolute; left:${clampedPercent}%; top:0; transform:translateX(-50%);"
+          >
+            <div
+              id="wpb-pill"
+              class="wpb-pill"
+              style="background:${barColor}; color:#fff; padding:5px 14px; border-radius:999px; font-size:14px; font-weight:700; white-space:nowrap; box-shadow:0 2px 8px rgba(66,133,244,0.30);"
+            >${currency}${current}</div>
+            <div
+              style="width:0; height:0; border-left:6px solid transparent; border-right:6px solid transparent; border-top:6px solid ${barColor}; margin:0 auto;"
+            ></div>
+          </div>
+
+          <!-- Track + fill -->
+          <div
+            id="wpb-track"
+            data-field="track"
+            style="background:${trackColor}; border-radius:999px; height:14px; overflow:hidden; width:100%;"
+          >
+            <div
+              id="wpb-fill"
+              data-field="fill"
+              data-percent="${Math.round(percent)}"
+              style="width:${clampedPercent}%; background:${barColor}; height:100%; border-radius:999px; min-width:4px;"
+            ></div>
+          </div>
+
+          <!-- Target label below bar, right-aligned -->
+          <p
+            id="wpb-target"
+            data-field="target-label"
+            style="margin:6px 0 0; text-align:right; color:${secondaryTextColor}; font-size:13px; font-weight:600;"
+          >${currency}${target}</p>
+        </div>
+
+        <!-- Discount circle (fixed size, never overlapped) -->
+        <div
+          id="wpb-circle"
+          data-field="discount-circle"
+          class="wpb-circle"
+          style="flex-shrink:0; width:52px; height:52px; background:${barColor}; border-radius:50%; display:flex; align-items:center; justify-content:center; box-shadow:0 4px 12px rgba(66,133,244,0.35);"
+        >
+          <span
+            id="wpb-circle-text"
+            data-field="discount-text"
+            class="wpb-circle-text"
+            style="color:#fff; font-size:11px; font-weight:800; text-align:center; line-height:1.2;"
+          >${String(discountText).replace(/\s/g, '<br/>')}</span>
+        </div>
+      </div>
+
+      <!-- Footer text (optional) -->
+      ${footerText ? `
+      <p
+        id="wpb-footer"
+        data-field="footer"
+        style="margin:16px 0 0; color:${secondaryTextColor}; font-size:13px; text-align:center; line-height:1.5;"
+      >${String(footerText)}</p>` : ''}
+    </div>
+  `;
+  return html.trim();
+}
+
+registerComponent({
+  id: 'wishlist-progress-bar',
+  name: 'Wishlist Progress Bar',
+  description: 'Shows progress toward wishlist goal with discount incentive',
+  category: 'engagement',
+  icon: '🎯',
+  props: [
+    { name: 'currentAmount', label: 'Current Amount', type: 'number', defaultValue: 390, min: 0, max: 10000 },
+    { name: 'targetAmount', label: 'Target Amount', type: 'number', defaultValue: 530, min: 1, max: 10000 },
+    { name: 'discountText', label: 'Discount Text', type: 'text', defaultValue: '10% OFF' },
+    { name: 'barColor', label: 'Accent Color', type: 'color', defaultValue: '#4285F4' },
+    { name: 'trackColor', label: 'Track Color', type: 'color', defaultValue: '#E0E0E0' },
+    { name: 'bgColor', label: 'Background Color', type: 'color', defaultValue: '#FFFFFF' },
+    { name: 'textColor', label: 'Text Color', type: 'color', defaultValue: '#1F2937' },
+    { name: 'secondaryTextColor', label: 'Secondary Text Color', type: 'color', defaultValue: '#6B7280' },
+    { name: 'currency', label: 'Currency Symbol', type: 'text', defaultValue: '$' },
+    { name: 'unlockLabel', label: 'Unlock Label', type: 'text', defaultValue: 'savings' },
+    { name: 'footerText', label: 'Footer Text (optional)', type: 'text', defaultValue: '' },
+  ],
+  defaultProps: {
+    currentAmount: 390,
+    targetAmount: 530,
+    discountText: '10% OFF',
+    barColor: '#4285F4',
+    trackColor: '#E0E0E0',
+    bgColor: '#FFFFFF',
+    textColor: '#1F2937',
+    secondaryTextColor: '#6B7280',
+    currency: '$',
+    unlockLabel: 'savings',
+    footerText: 'Make it yours—take 10% off and outfit your next voyage with confidence.',
+  },
+  render: renderWishlistProgressBar,
+});

--- a/src/custom-components/index.ts
+++ b/src/custom-components/index.ts
@@ -1,0 +1,5 @@
+import './definitions/wishlist-progress-bar';
+import './definitions/product-carousel';
+import './definitions/two-column-coupon-list';
+
+export * from './registry';

--- a/src/custom-components/registry.ts
+++ b/src/custom-components/registry.ts
@@ -1,0 +1,36 @@
+export interface ComponentPropSchema {
+  name: string;
+  label: string;
+  type: 'number' | 'text' | 'color' | 'select' | 'toggle' | 'range';
+  defaultValue: unknown;
+  options?: { label: string; value: unknown }[];
+  min?: number;
+  max?: number;
+  step?: number;
+}
+
+export interface CustomComponentDefinition {
+  id: string;
+  name: string;
+  description: string;
+  category: 'engagement' | 'commerce' | 'layout';
+  icon: string;
+  thumbnail?: string;
+  props: ComponentPropSchema[];
+  defaultProps: Record<string, unknown>;
+  render: (props: Record<string, unknown>) => string;
+}
+
+export const COMPONENT_REGISTRY: Map<string, CustomComponentDefinition> = new Map();
+
+export function registerComponent(def: CustomComponentDefinition): void {
+  COMPONENT_REGISTRY.set(def.id, def);
+}
+
+export function getAllComponents(): CustomComponentDefinition[] {
+  return Array.from(COMPONENT_REGISTRY.values());
+}
+
+export function getComponent(id: string): CustomComponentDefinition | undefined {
+  return COMPONENT_REGISTRY.get(id);
+}

--- a/src/custom-components/utils/designUpdater.ts
+++ b/src/custom-components/utils/designUpdater.ts
@@ -1,0 +1,109 @@
+import { getComponent } from '../registry';
+
+function randomId(): string {
+  return Math.random().toString(36).slice(2, 10);
+}
+
+/**
+ * Walk through the Unlayer design JSON and update a specific HTML block's content.
+ * Returns a new design object (does not mutate the original).
+ */
+export function updateComponentInDesign(
+  design: unknown,
+  htmlBlockId: string,
+  newHtml: string
+): unknown {
+  const updatedDesign = JSON.parse(JSON.stringify(design)) as {
+    body?: { rows?: Array<{ columns?: Array<{ contents?: unknown[] }> }> };
+  };
+
+  const rows = updatedDesign?.body?.rows;
+  if (!Array.isArray(rows)) return updatedDesign;
+
+  for (const row of rows) {
+    const columns = row.columns;
+    if (!Array.isArray(columns)) continue;
+    for (const col of columns) {
+      const contents = col.contents;
+      if (!Array.isArray(contents)) continue;
+      for (const content of contents) {
+        const c = content as { id?: string; type?: string; values?: { html?: string } };
+        if (c.id === htmlBlockId && c.type === 'html' && c.values) {
+          c.values.html = newHtml;
+          return updatedDesign;
+        }
+      }
+    }
+  }
+
+  console.warn(`HTML block with ID ${htmlBlockId} not found in design`);
+  return updatedDesign;
+}
+
+/**
+ * Inject a new custom component as a new row at the end of the design.
+ */
+export function injectComponentRow(design: unknown, componentId: string): unknown {
+  const comp = getComponent(componentId);
+  if (!comp) return design;
+
+  const updatedDesign = JSON.parse(JSON.stringify(design)) as {
+    body?: { rows?: unknown[]; id?: string };
+  };
+
+  const html = comp.render(comp.defaultProps as Record<string, unknown>);
+  const contentId = `cust_${Date.now()}_${randomId()}`;
+  const columnId = `cust_col_${Date.now()}_${randomId()}`;
+  const rowId = `cust_row_${Date.now()}_${randomId()}`;
+
+  const newRow = {
+    id: rowId,
+    cells: [1],
+    columns: [
+      {
+        id: columnId,
+        contents: [
+          {
+            id: contentId,
+            type: 'html',
+            values: {
+              html,
+              containerPadding: '10px',
+              _meta: { htmlID: contentId, htmlClassNames: '' },
+            },
+          },
+        ],
+        values: {},
+      },
+    ],
+    values: {
+      displayCondition: null,
+      columns: false,
+      backgroundColor: '',
+      columnsBackgroundColor: '',
+      backgroundImage: {
+        url: '',
+        fullWidth: true,
+        repeat: false,
+        center: true,
+        cover: false,
+      },
+      padding: '0px',
+      anchor: '',
+      hideDesktop: false,
+      _meta: { htmlID: rowId, htmlClassNames: 'u_row' },
+      selectable: true,
+      draggable: true,
+      duplicatable: true,
+      deletable: true,
+      hideable: true,
+    },
+  };
+
+  const d = updatedDesign as { body?: { id?: string; rows?: unknown[] } };
+  if (!d.body) d.body = { id: 'body', rows: [] };
+  if (!d.body.rows) d.body.rows = [];
+  d.body.rows.push(newRow);
+
+  return updatedDesign;
+}

--- a/src/custom-components/utils/detection.ts
+++ b/src/custom-components/utils/detection.ts
@@ -1,0 +1,75 @@
+import { getComponent, type CustomComponentDefinition } from '../registry';
+
+export interface DetectedComponent {
+  componentId: string;
+  componentDef: CustomComponentDefinition;
+  currentProps: Record<string, unknown>;
+  htmlBlockId: string;
+  rawHtml: string;
+}
+
+/**
+ * Parse an HTML string to detect if it contains a custom component.
+ * Returns null if not a custom component.
+ */
+export function detectCustomComponent(html: string): { componentId: string; props: Record<string, unknown> } | null {
+  if (!html) return null;
+
+  const componentMatch = html.match(/data-component="([^"]+)"/);
+  if (!componentMatch) return null;
+
+  const componentId = componentMatch[1];
+
+  const propsMatch = html.match(/data-props='([^']*(?:\\'[^']*)*)'/);
+  let props: Record<string, unknown> = {};
+
+  if (propsMatch) {
+    try {
+      const unescaped = propsMatch[1].replace(/\\'/g, "'");
+      props = JSON.parse(unescaped) as Record<string, unknown>;
+    } catch {
+      console.warn('Failed to parse component props:', propsMatch[1]);
+    }
+  }
+
+  return { componentId, props };
+}
+
+/**
+ * Scan entire design JSON to find all custom components.
+ */
+export function findAllCustomComponentsInDesign(design: unknown): DetectedComponent[] {
+  const results: DetectedComponent[] = [];
+  const body = (design as { body?: { rows?: unknown[] } })?.body;
+  const rows = body?.rows;
+  if (!Array.isArray(rows)) return results;
+
+  for (const row of rows) {
+    const columns = (row as { columns?: unknown[] }).columns;
+    if (!Array.isArray(columns)) continue;
+    for (const col of columns) {
+      const contents = (col as { contents?: unknown[] }).contents;
+      if (!Array.isArray(contents)) continue;
+      for (const content of contents) {
+        const c = content as { id?: string; type?: string; values?: { html?: string } };
+        if (c.type === 'html' && c.values?.html) {
+          const detected = detectCustomComponent(c.values.html);
+          if (detected) {
+            const compDef = getComponent(detected.componentId);
+            if (compDef) {
+              results.push({
+                componentId: detected.componentId,
+                componentDef: compDef,
+                currentProps: detected.props,
+                htmlBlockId: c.id ?? '',
+                rawHtml: c.values.html,
+              });
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return results;
+}

--- a/src/features/base-template/components/BaseTemplateBuilder.tsx
+++ b/src/features/base-template/components/BaseTemplateBuilder.tsx
@@ -121,7 +121,6 @@ export const BaseTemplateBuilder: React.FC<BaseTemplateBuilderProps> = ({
       form.resetFields();
     } catch (error) {
       console.error('Failed to save template:', error);
-      message.error('Failed to save template');
     }
   };
 
@@ -158,17 +157,9 @@ export const BaseTemplateBuilder: React.FC<BaseTemplateBuilderProps> = ({
             saveMode="base"
           />
           <Card style={{ marginTop: 16 }}>
-            <Space>
+            <Space className="w-full justify-end">
               <Button onClick={handlePreviousStep}>Previous</Button>
               <Button onClick={onCancel}>Cancel</Button>
-              <Button
-                type="primary"
-                icon={<SaveOutlined />}
-                loading={loading}
-                onClick={handleFinish}
-              >
-                Save Template
-              </Button>
             </Space>
           </Card>
         </div>

--- a/src/features/base-template/hooks/useBaseTemplateActions.ts
+++ b/src/features/base-template/hooks/useBaseTemplateActions.ts
@@ -31,7 +31,6 @@ export const useBaseTemplateActions = () => {
       });
       categoryActions.setCategories(response.results || []);
     } catch (error) {
-      message.error('Failed to load categories');
       console.error('Load categories error:', error);
     } finally {
       setLoading(false);
@@ -50,7 +49,6 @@ export const useBaseTemplateActions = () => {
       const category = await api.baseTemplateCategories.getCategoryById(id);
       return category;
     } catch (error) {
-      message.error('Failed to load category');
       console.error('Get category by id error:', error);
       return null;
     } finally {
@@ -71,11 +69,6 @@ export const useBaseTemplateActions = () => {
       message.success('Category deleted successfully');
       await loadCategories();
     } catch (error: any) {
-      if (error?.statusCode === 409) {
-        message.error(error.message);
-      } else {
-        message.error('Failed to delete category');
-      }
       console.error('Delete category error:', error);
       throw error;
     } finally {
@@ -133,7 +126,6 @@ export const useBaseTemplateActions = () => {
 
       templateActions.setTemplates(templates);
     } catch (error) {
-      message.error('Failed to load templates');
       console.error('Load templates error:', error);
     } finally {
       setLoading(false);
@@ -159,11 +151,6 @@ export const useBaseTemplateActions = () => {
 
       await loadCategories();
     } catch (error: any) {
-      if (error?.statusCode === 409) {
-        message.error(error.message);
-      } else {
-        message.error('Failed to save category');
-      }
       console.error('Create category error:', error);
       throw error;
     } finally {
@@ -184,11 +171,6 @@ export const useBaseTemplateActions = () => {
       message.success('Template deleted successfully');
       await loadTemplates();
     } catch (error: any) {
-      if (error?.statusCode === 409) {
-        message.error(error.message);
-      } else {
-        message.error('Failed to delete template');
-      }
       console.error('Delete template error:', error);
       throw error;
     } finally {
@@ -222,7 +204,6 @@ export const useBaseTemplateActions = () => {
       await loadTemplates();
       return true;
     } catch (error) {
-      message.error('Failed to create base template');
       console.error('Save template error:', error);
       throw error;
     } finally {
@@ -243,11 +224,6 @@ export const useBaseTemplateActions = () => {
       message.success(`Template status updated to ${status} successfully`);
       await loadTemplates();
     } catch (error: any) {
-      if (error?.statusCode === 409) {
-        message.error(error.message);
-      } else {
-        message.error('Failed to update template status');
-      }
       console.error('Update template status error:', error);
       throw error;
     } finally {

--- a/src/features/base-template/hooks/useBaseTemplateCategoriesListing.ts
+++ b/src/features/base-template/hooks/useBaseTemplateCategoriesListing.ts
@@ -67,11 +67,6 @@ export const useBaseTemplateCategoriesListing = () => {
       message.success('Category deleted successfully');
       await getCategories();
     } catch (error: any) {
-      if (error?.statusCode === 409) {
-        message.error(error.message);
-      } else {
-        message.error('Failed to delete category');
-      }
       throw error;
     } finally {
       setLoading(false);

--- a/src/features/builder/components/BuilderMain.tsx
+++ b/src/features/builder/components/BuilderMain.tsx
@@ -118,7 +118,8 @@ const BuilderMain: React.FC<BuilderMainProps> = ({
             device_type_id: data.device_type_id,
           } as any);
         } else {
-          // Create blank template from scratch
+          // Create blank template from scratch (shopper_ids sent for duplicate check)
+          const shopperIdsForCreate = data.is_generic ? shoppers.map((s) => s.id) : data.shopper_ids;
           const newTemplate = await createTemplate({
             name: data.name,
             description: data.description,
@@ -128,6 +129,7 @@ const BuilderMain: React.FC<BuilderMainProps> = ({
             is_generic: data.is_generic || false,
             account_ids: Array.isArray(data.account_ids) ? data.account_ids : [],
             device_type_id: data.device_type_id,
+            shopper_ids: shopperIdsForCreate,
           });
           newTemplateId = newTemplate.id;
         }
@@ -135,9 +137,7 @@ const BuilderMain: React.FC<BuilderMainProps> = ({
         // MIGRATED: Update the template ID in Zustand store
         actions.setCurrentTemplateId(newTemplateId);
 
-        let shopperIds = data.is_generic
-          ? shoppers.map((s) => s.id)
-          : data.shopper_ids;
+        const shopperIds = data.is_generic ? shoppers.map((s) => s.id) : data.shopper_ids;
 
         await assignTemplateToShoppers(newTemplateId, shopperIds);
 
@@ -147,8 +147,7 @@ const BuilderMain: React.FC<BuilderMainProps> = ({
 
         navigate(`/coupon-builder-v2/popup-builder/${newTemplateId}/edit`);
       }
-    } catch (error) {
-      message.error('Failed to create template.');
+    } catch (error: any) {
       console.error('Config submit error:', error);
       loadingActions.setTemplateByIdLoading(false);
     } finally {

--- a/src/features/builder/components/ReminderTabStep.tsx
+++ b/src/features/builder/components/ReminderTabStep.tsx
@@ -37,7 +37,6 @@ const ReminderTabStep: React.FC<ReminderTabStepProps> = ({
     onSave: onSave,
     onError: (error) => {
       console.error('Reminder tab autosave error:', error);
-      message.error(`Autosave failed: ${error.message}`);
     },
   });
 
@@ -54,7 +53,6 @@ const ReminderTabStep: React.FC<ReminderTabStepProps> = ({
       message.success('Reminder tab configuration saved successfully!');
     } catch (error) {
       console.error('Save error:', error);
-      message.error('Failed to save reminder tab configuration');
     }
   }, [performManualSave]);
 

--- a/src/features/builder/hooks/useBuilderMain.ts
+++ b/src/features/builder/hooks/useBuilderMain.ts
@@ -27,22 +27,19 @@ export const useBuilderMain = () => {
       return response;
     } catch (error) {
       console.error('Error getting template fields:', error);
-      message.error('Failed to get template fields');
       throw error;
     }
   };
 
   const createTemplate = async (data: any) => {
     if (!api) {
-      message.error('API client is required');
       throw new Error('API client is required');
     }
     try {
       const response = await api.templates.createTemplate(data);
       return response;
-    } catch (error) {
+    } catch (error: any) {
       console.error('Error creating template:', error);
-      message.error('Failed to create template');
       throw error;
     }
   };
@@ -57,7 +54,6 @@ export const useBuilderMain = () => {
       return response;
     } catch (error) {
       console.error('Error updating template:', error);
-      message.error('Failed to update template');
       throw error;
     }
   };
@@ -72,7 +68,6 @@ export const useBuilderMain = () => {
       return response;
     } catch (error) {
       console.error('Error assigning template:', error);
-      message.error('Failed to assign template');
       throw error;
     }
   };
@@ -116,7 +111,6 @@ export const useBuilderMain = () => {
       };
     } catch (error) {
       console.error('Error loading template:', error);
-      message.error('Failed to load template');
       throw error;
     } finally {
       loadingActions.setTemplateByIdLoading(false);
@@ -141,7 +135,6 @@ export const useBuilderMain = () => {
 
       templateActions.setDesignJson(baseTemplate.builder_state_json ?? null);
     } catch (error) {
-      message.error('Failed to load template');
     }
   };
 

--- a/src/features/builder/hooks/useUnlayerImageUpload.ts
+++ b/src/features/builder/hooks/useUnlayerImageUpload.ts
@@ -127,7 +127,6 @@ export const useUnlayerImageUpload = (
       } catch (error) {
         console.error('❌ Image upload failed:', error);
         message.destroy();
-        message.error(`Upload failed: ${(error as Error).message}`);
         
         // Signal error to Unlayer
         done({ 
@@ -164,7 +163,6 @@ export const useUnlayerImageUpload = (
               
             } catch (error) {
               message.destroy();
-              message.error(`Upload failed: ${(error as Error).message}`);
               done({ error: 'Upload failed' });
             }
           }
@@ -174,7 +172,6 @@ export const useUnlayerImageUpload = (
         
       } catch (error) {
         console.error('❌ Image selection failed:', error);
-        message.error('Image selection failed');
         done({ error: 'Selection failed' });
       }
     });

--- a/src/features/canned-content/components/content-list.tsx
+++ b/src/features/canned-content/components/content-list.tsx
@@ -115,7 +115,6 @@ const CannedContentList: React.FC<CannedContentListProps> = ({
       getContent();
     } catch (error) {
       console.error('Error deleting content:', error);
-      message.error('Failed to delete content');
     }
   };
 
@@ -133,7 +132,6 @@ const CannedContentList: React.FC<CannedContentListProps> = ({
       getContent();
     } catch (error) {
       console.error('Error saving content:', error);
-      message.error('Failed to save content');
     }
   };
 

--- a/src/features/canned-content/hooks/use-content.ts
+++ b/src/features/canned-content/hooks/use-content.ts
@@ -24,7 +24,6 @@ export const useContent = () => {
       });
     } catch (error) {
       console.error('Error loading content:', error);
-      message.error('Failed to load content');
     } finally {
       loadingActions.setContentListingLoading(false);
     }
@@ -38,7 +37,6 @@ export const useContent = () => {
       actions.setContent(response);
     } catch (error) {
       console.error('Error loading content details:', error);
-      message.error('Failed to load content details');
     } finally {
       loadingActions.setContentListingLoading(false);
     }
@@ -58,7 +56,6 @@ export const useContent = () => {
       actions.setContent(response);
     } catch (error) {
       console.error('Error creating content:', error);
-      message.error('Failed to create content');
     } finally {
       loadingActions.setContentActionLoading(false);
     }
@@ -78,7 +75,6 @@ export const useContent = () => {
       actions.setContent(response);
     } catch (error) {
       console.error('Error updating content:', error);
-      message.error('Failed to update content');
     } finally {
       loadingActions.setContentActionLoading(false);
     }
@@ -92,7 +88,6 @@ export const useContent = () => {
       actions.setContent(null);
     } catch (error) {
       console.error('Error deleting content:', error);
-      message.error('Failed to delete content');
     } finally {
       loadingActions.setContentActionLoading(false);
     }
@@ -106,7 +101,6 @@ export const useContent = () => {
       actions.setIndustries(response);
     } catch (error) {
       console.error('Error getting industries:', error);
-      message.error('Failed to get industries');
     } finally {
       loadingActions.setContentSubDataLoading(false);
     }
@@ -120,7 +114,6 @@ export const useContent = () => {
       actions.setFields(response.map((field) => ({key: field.field, value: +field.id})));
     } catch (error) {
       console.error('Error getting fields:', error);
-      message.error('Failed to get fields');
     } finally {
       loadingActions.setContentSubDataLoading(false);
     }

--- a/src/features/client-flow/components/ClientEditorStep.tsx
+++ b/src/features/client-flow/components/ClientEditorStep.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState, useRef, useCallback } from 'react';
 import { message, Alert, Button, Card, Row, Col, Space, Typography, Badge, Spin, Popover, Modal } from 'antd';
 import { ArrowRightOutlined, SaveOutlined, InfoCircleOutlined, LogoutOutlined } from '@ant-design/icons';
 import EmailEditor, { UnlayerOptions } from 'react-email-editor';
@@ -9,6 +9,11 @@ import { useUnlayerEditor } from '../../builder/hooks/useUnlayerEditor';
 import { useUnlayerDeviceOptions } from '../../builder/hooks/useUnlayerDeviceOptions';
 import { manageEditorMode, manageMergeTags } from '../../builder/utils';
 import { selectFirstBlockWhenReady, hidePopupTabInEditor } from '../../builder/utils/unlayerDefaultSelection';
+import { getAllComponents, getComponent } from '@/custom-components';
+import { detectCustomComponent, findAllCustomComponentsInDesign, type DetectedComponent } from '@/custom-components/utils/detection';
+import { updateComponentInDesign } from '@/custom-components/utils/designUpdater';
+import { OverlayPropertyPanel } from '@/custom-components/components/OverlayPropertyPanel';
+import { ActiveComponentsList } from '@/custom-components/components/ActiveComponentsList';
 
 const { Title, Text } = Typography;
 
@@ -53,6 +58,73 @@ export const ClientEditorStep: React.FC<ClientEditorStepProps> = ({
   const { builderAutosaving } = useLoadingStore();
   const { devices, defaultDevice } = useUnlayerDeviceOptions();
 
+  const userRole = 'client' as const;
+  const [selectedComponent, setSelectedComponent] = useState<DetectedComponent | null>(null);
+  const [allCustomComponents, setAllCustomComponents] = useState<DetectedComponent[]>([]);
+  const [isReloading, setIsReloading] = useState(false);
+  const lastDesignRef = useRef<unknown>(null);
+  const updateTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isUpdatingRef = useRef(false);
+
+  const extendEditorReady = useCallback((unlayer: any) => {
+    unlayer.registerProvider('blocks', (_params: any, done: (blocks: any[]) => void) => {
+      const components = getAllComponents();
+      const blocks = components.map((comp) => ({
+        id: `custom-${comp.id}`,
+        name: comp.name,
+        category: 'Custom Components',
+        tags: [comp.category, comp.name.toLowerCase()],
+        data: {
+          body: {
+            rows: [
+              {
+                cells: [1],
+                columns: [
+                  {
+                    contents: [
+                      {
+                        type: 'html',
+                        values: {
+                          html: comp.render(comp.defaultProps as Record<string, unknown>),
+                          containerPadding: '10px',
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      }));
+      done(blocks);
+    });
+
+    unlayer.addEventListener('design:updated', (data: any) => {
+      unlayer.exportHtml((exportData: any) => {
+        lastDesignRef.current = exportData.design;
+        const found = findAllCustomComponentsInDesign(exportData.design);
+        setAllCustomComponents(found);
+      });
+      if (data?.type === 'content' && data?.item?.type === 'html') {
+        const html = data.item.values?.html ?? '';
+        const detected = detectCustomComponent(html);
+        if (detected) {
+          const compDef = getComponent(detected.componentId);
+          if (compDef) {
+            setSelectedComponent({
+              componentId: detected.componentId,
+              componentDef: compDef,
+              currentProps: detected.props,
+              htmlBlockId: data.item.id ?? '',
+              rawHtml: html,
+            });
+          }
+        }
+      }
+    });
+  }, []);
+
   const {
     editorRef,
     isReady,
@@ -71,7 +143,61 @@ export const ClientEditorStep: React.FC<ClientEditorStepProps> = ({
     templateId: templateId || currentTemplateId || undefined,
     accountId: authProvider?.accountId,
     enableCustomImageUpload: true,
+    extendEditorReady,
   });
+
+  const hasUnsavedChangesRef = useRef(hasUnsavedChanges);
+  useEffect(() => {
+    hasUnsavedChangesRef.current = hasUnsavedChanges;
+  }, [hasUnsavedChanges]);
+  useEffect(() => {
+    const handler = (e: BeforeUnloadEvent) => {
+      if (hasUnsavedChangesRef.current) {
+        e.preventDefault();
+      }
+    };
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, []);
+
+  const handlePropsChange = useCallback(
+    (componentId: string, htmlBlockId: string, newProps: Record<string, unknown>) => {
+      const comp = getComponent(componentId);
+      const design = lastDesignRef.current;
+      if (!comp || !design) return;
+
+      const newHtml = comp.render(newProps);
+      const updatedDesign = updateComponentInDesign(design, htmlBlockId, newHtml);
+
+      if (updateTimeoutRef.current) clearTimeout(updateTimeoutRef.current);
+      updateTimeoutRef.current = setTimeout(() => {
+        if (isUpdatingRef.current) return;
+        isUpdatingRef.current = true;
+        const unlayer = editorRef.current?.editor;
+        if (unlayer) {
+          setIsReloading(true);
+          unlayer.loadDesign(updatedDesign as any);
+          lastDesignRef.current = updatedDesign;
+          setTimeout(() => {
+            isUpdatingRef.current = false;
+            setIsReloading(false);
+          }, 600);
+        }
+      }, 800);
+    },
+    [editorRef]
+  );
+
+  // Sync custom components list and lastDesignRef when editor is ready
+  useEffect(() => {
+    if (!isReady || !editorRef.current?.editor || !templateState) return;
+    const unlayer = editorRef.current.editor;
+    unlayer.exportHtml((data: any) => {
+      lastDesignRef.current = data.design;
+      const found = findAllCustomComponentsInDesign(data.design);
+      setAllCustomComponents(found);
+    });
+  }, [isReady, templateState]);
 
   // Remove Unlayer branding
   useEffect(() => {
@@ -95,7 +221,6 @@ export const ClientEditorStep: React.FC<ClientEditorStepProps> = ({
       message.success('Design saved successfully!');
     } catch (error) {
       console.error('Manual save failed:', error);
-      message.error('Failed to save design');
     }
   };
 
@@ -165,7 +290,7 @@ export const ClientEditorStep: React.FC<ClientEditorStepProps> = ({
       {/* Error Display */}
       {error && (
         <Alert
-          message="Error"
+          message="Autosave failed — will retry"
           description={error}
           type="error"
           closable
@@ -175,62 +300,109 @@ export const ClientEditorStep: React.FC<ClientEditorStepProps> = ({
       )}
 
       {/* Editor Container - only mount when template (and devices) is loaded so device view is correct */}
-      <Card>
-        <div
-          style={{
-            height: '700px',
-            border: '1px solid #d9d9d9',
-            borderRadius: '6px',
-            overflow: 'hidden',
-          }}
-        >
-          {!templateState ? (
-            <div className="flex items-center justify-center h-full min-h-[400px]">
-              <Spin size="large" tip="Loading editor..." />
-            </div>
-          ) : (
-            <EmailEditor
-              key={`bl-client-editor-${templateId ?? ''}-${devices.join('-')}-${defaultDevice}`}
-              editorId="bl-client-editor"
-              ref={editorRef}
-              onReady={(unlayer) => {
-                onEditorReady(unlayer);
-                selectFirstBlockWhenReady(unlayer, 'bl-client-editor');
-                hidePopupTabInEditor('bl-client-editor');
-              }}
-              options={{
-                ...unlayerConfig,
-                appearance: {
-                  ...unlayerConfig.appearance,
-                  panels: {
-                    ...unlayerConfig.appearance?.panels,
-                    tools: {
-                      ...unlayerConfig.appearance?.panels?.tools,
-                      dock: 'left',
-                    },
-                  },
-                },
-                tools: manageEditorMode(true), // Always design mode for client
-                mergeTags: manageMergeTags(),
-                devices,
-                defaultDevice,
-                tabs: {
-                  content: { enabled: false },
-                  blocks: { enabled: false },
-                  popup: { enabled: false },
-                  Popup: { enabled: false },
-                  dev: { enabled: false },
-                },
-                features: { audit: false },
-              }}
+      <div style={{ position: 'relative', display: 'flex', width: '100%' }}>
+        {allCustomComponents.length > 0 && (
+          <ActiveComponentsList
+            components={allCustomComponents}
+            selectedComponent={selectedComponent}
+            onSelect={setSelectedComponent}
+          />
+        )}
+        <div style={{ position: 'relative', flex: 1 }}>
+          <Card>
+            <div
               style={{
                 height: '700px',
-                width: '100%',
+                border: '1px solid #d9d9d9',
+                borderRadius: '6px',
+                overflow: 'hidden',
               }}
+            >
+              {!templateState ? (
+                <div className="flex items-center justify-center h-full min-h-[400px]">
+                  <Spin size="large" tip="Loading editor..." />
+                </div>
+              ) : (
+                <EmailEditor
+                  key={`bl-client-editor-${templateId ?? ''}-${devices.join('-')}-${defaultDevice}`}
+                  editorId="bl-client-editor"
+                  ref={editorRef}
+                  onReady={(unlayer) => {
+                    onEditorReady(unlayer);
+                    selectFirstBlockWhenReady(unlayer, 'bl-client-editor');
+                    hidePopupTabInEditor('bl-client-editor');
+                  }}
+                  options={{
+                    ...unlayerConfig,
+                    appearance: {
+                      ...unlayerConfig.appearance,
+                      panels: {
+                        ...unlayerConfig.appearance?.panels,
+                        tools: {
+                          ...unlayerConfig.appearance?.panels?.tools,
+                          dock: 'left',
+                        },
+                      },
+                    },
+                    tools: { ...manageEditorMode(true), html: { enabled: false } },
+                    mergeTags: manageMergeTags(),
+                    devices,
+                    defaultDevice,
+                    tabs: {
+                      content: { enabled: false },
+                      blocks: { enabled: false },
+                      popup: { enabled: false },
+                      Popup: { enabled: false },
+                      dev: { enabled: false },
+                    },
+                    features: {
+                      ...unlayerConfig.features,
+                      textEditor: { triggerChangeWhileEditing: true, debounce: 300 } as Record<string, unknown>,
+                      audit: false,
+                    },
+                    customCSS: [
+                      `.blockbuilder-content-tool-html .blockbuilder-options-content { display: none !important; }`,
+                      `.blockbuilder-content-tool-html .blockbuilder-options::after { content: 'Use the properties panel to edit this component →'; display: block; padding: 20px; text-align: center; color: #9CA3AF; font-size: 13px; }`,
+                    ],
+                  }}
+                  style={{
+                    height: '700px',
+                    width: '100%',
+                  }}
+                />
+              )}
+            </div>
+          </Card>
+
+          {isReloading && (
+            <div
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                right: 360,
+                bottom: 0,
+                background: 'rgba(255,255,255,0.7)',
+                zIndex: 9998,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              <span style={{ fontSize: '14px', color: '#6B7280' }}>Updating preview...</span>
+            </div>
+          )}
+
+          {selectedComponent && (
+            <OverlayPropertyPanel
+              component={selectedComponent}
+              onPropsChange={handlePropsChange}
+              onClose={() => setSelectedComponent(null)}
+              userRole={userRole}
             />
           )}
         </div>
-      </Card>
+      </div>
 
       {/* Navigation */}
       <div className="flex justify-end gap-2 mt-6">

--- a/src/features/client-flow/components/ClientReminderTabStep.tsx
+++ b/src/features/client-flow/components/ClientReminderTabStep.tsx
@@ -40,7 +40,6 @@ export const ClientReminderTabStep: React.FC<ClientReminderTabStepProps> = ({
     templateId: currentTemplateId || undefined,
     onError: (error) => {
       console.error('Reminder tab autosave error:', error);
-      message.error(`Autosave failed: ${error.message}`);
     },
   });
 
@@ -57,7 +56,6 @@ export const ClientReminderTabStep: React.FC<ClientReminderTabStepProps> = ({
       message.success('Reminder tab configuration saved!');
     } catch (error) {
       console.error('Save error:', error);
-      message.error('Failed to save reminder tab configuration');
     }
   }, [performManualSave]);
 

--- a/src/features/client-flow/components/content-form.tsx
+++ b/src/features/client-flow/components/content-form.tsx
@@ -61,7 +61,6 @@ const ContentForm = () => {
       message.success('Content saved successfully!');
     } catch (error) {
       console.error('Error saving content:', error);
-      message.error('Failed to save content');
     } finally {
       setIsLoading(false);
     }

--- a/src/features/client-flow/components/review-actions.tsx
+++ b/src/features/client-flow/components/review-actions.tsx
@@ -1,4 +1,4 @@
-import { Button, Space, Tooltip } from 'antd';
+import { Button } from 'antd';
 import { Edit, ThumbsUp, Eye } from 'lucide-react';
 import React from 'react';
 import { useClientFlowStore } from '@/stores/clientFlowStore';
@@ -8,9 +8,13 @@ import { cn } from '@/lib/utils';
 interface ReviewActionsProps {
   type: 'desktop' | 'mobile';
   goToEditTemplate: () => void;
+  /** When true, all actions render in one row (for use inside template card). */
+  inline?: boolean;
 }
 
-const ReviewActions: React.FC<ReviewActionsProps> = ({ type, goToEditTemplate }) => {
+const buttonBase = 'h-9 flex items-center transition-all duration-300 ease-in-out whitespace-nowrap';
+
+const ReviewActions: React.FC<ReviewActionsProps> = ({ type, goToEditTemplate, inline }) => {
   const { feedbackData } = useClientFlowStore();
   const { actions: genericActions } = useGenericStore();
 
@@ -20,64 +24,94 @@ const ReviewActions: React.FC<ReviewActionsProps> = ({ type, goToEditTemplate })
   };
   const wordCount = countWords(currentFeedback);
   const isFeedbackValid = wordCount >= 5;
-  const isApproveDisabled = isFeedbackValid; // Disable approve when feedback is valid (user is providing feedback)
+  const isApproveDisabled = isFeedbackValid;
 
   const handlePreview = () => {
     genericActions.setBrowserPreviewModalOpen(true);
   };
 
+  const approveClassName = cn(
+    buttonBase,
+    isApproveDisabled
+      ? 'bg-gray-300 border-gray-300 cursor-not-allowed'
+      : 'bg-green-500 border-green-500 hover:!bg-green-600 hover:!border-green-600'
+  );
+
+  if (inline) {
+    return (
+      <div
+        className="inline-flex border border-gray-400 bg-gray-200 overflow-hidden shadow-sm p-1"
+        role="group"
+        aria-label="Template actions"
+      >
+        <button
+          type="button"
+          onClick={handlePreview}
+          className={cn(
+            buttonBase,
+            'gap-1.5 px-4 border-0 border-r border-gray-200 bg-white text-gray-700 hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-inset'
+          )}
+        >
+          <Eye size={16} className="shrink-0" />
+          <span>Preview</span>
+        </button>
+        <button
+          type="button"
+          onClick={goToEditTemplate}
+          className={cn(
+            buttonBase,
+            'gap-1.5 px-4 border-0 border-r border-gray-200 bg-white text-gray-700 hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-inset'
+          )}
+        >
+          <Edit size={16} className="shrink-0" />
+          <span>Edit</span>
+        </button>
+        <button
+          type="button"
+          disabled={isApproveDisabled}
+          className={cn(
+            buttonBase,
+            'gap-1.5 px-4 border-0 bg-blue-500 text-white hover:bg-blue-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-inset disabled:opacity-60 disabled:cursor-not-allowed disabled:hover:bg-blue-500',
+            isApproveDisabled && '!bg-gray-300 !text-gray-500 hover:!bg-gray-300'
+          )}
+        >
+          <ThumbsUp size={16} className="shrink-0" />
+          <span>Approve</span>
+        </button>
+      </div>
+    );
+  }
+
   return (
-    <div className='w-full'>
+    <div className="w-full">
       <Button
-            type="primary"
-            icon={<Eye size={16} />}
-            onClick={handlePreview}
-            size="middle"
-            className={cn(
-              "h-9 w-full mb-4 flex items-center"
-            )}
-          >
-            <span className={cn(
-              "transition-all duration-300 ease-in-out whitespace-nowrap"
-            )}>
-              Preview Template
-            </span>
-          </Button>
-      <div className={cn(
-        "flex items-end gap-2 px-2 transition-all duration-300 ease-in-out"
-      )}>
-          <Button
-            type="default"
-            icon={<Edit size={16} />}
-            onClick={goToEditTemplate}
-            size="middle"
-            className={cn(
-              "h-9 w-full flex items-center ")}
-          >
-            <span className={cn(
-              "transition-all duration-300 ease-in-out whitespace-nowrap"
-            )}>
-              Edit
-            </span>
-          </Button>
-          <Button
-            type="primary"
-            icon={<ThumbsUp size={16} />}
-            disabled={isApproveDisabled}
-            size="middle"
-            className={cn(
-              "h-9 w-full flex items-center transition-all duration-300 ease-in-out",
-              isApproveDisabled
-                ? 'bg-gray-300 border-gray-300 cursor-not-allowed'
-                : 'bg-green-500 border-green-500 hover:!bg-green-600 hover:!border-green-600'
-            )}
-          >
-            <span className={cn(
-              "transition-all duration-300 ease-in-out whitespace-nowrap"
-            )}>
-              Approve
-            </span>
-          </Button>
+        type="primary"
+        icon={<Eye size={16} />}
+        onClick={handlePreview}
+        size="middle"
+        className={cn(buttonBase, 'w-full mb-4')}
+      >
+        Preview Template
+      </Button>
+      <div className="flex items-end gap-2 px-2">
+        <Button
+          type="default"
+          icon={<Edit size={16} />}
+          onClick={goToEditTemplate}
+          size="middle"
+          className={cn(buttonBase, 'w-full')}
+        >
+          Edit
+        </Button>
+        <Button
+          type="primary"
+          icon={<ThumbsUp size={16} />}
+          disabled={isApproveDisabled}
+          size="middle"
+          className={cn(buttonBase, 'w-full', approveClassName)}
+        >
+          Approve
+        </Button>
       </div>
     </div>
   );

--- a/src/features/client-flow/components/shopper-details.tsx
+++ b/src/features/client-flow/components/shopper-details.tsx
@@ -18,6 +18,7 @@ interface ShopperDetailsProps {
 
 const ShopperDetails: React.FC<ShopperDetailsProps> = ({ compact = false, displayMode }) => {
   const { getShopperDetails } = useClientFlow();
+  const accountDetails = useGenericStore((s) => s.accountDetails);
 
   const { activeContentShopper, shopperDetails } = useClientFlowStore();
   const { shopperDetailsLoading } = useLoadingStore();
@@ -34,6 +35,17 @@ const ShopperDetails: React.FC<ShopperDetailsProps> = ({ compact = false, displa
       setShopperDetailsData(shopperDetailsDummyData.data[0]);
     }
   }, [shopperDetails]);
+
+  useEffect(() => {
+    if (activeContentShopper?.content?.id && accountDetails?.id && accountDetails?.company_id) {
+      getShopperDetails({
+        account_id: +accountDetails.id,
+        company_id: +accountDetails.company_id,
+        shopper_id: +activeContentShopper.content.id,
+        shopper_name: activeContentShopper.content.name ?? '',  
+      });
+    }
+  }, [activeContentShopper, accountDetails]);
 
   if (shopperDetailsLoading) {
     return (

--- a/src/features/client-flow/components/template-review-selector.tsx
+++ b/src/features/client-flow/components/template-review-selector.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { Tabs, Typography } from 'antd';
+import { ClientFlowData } from '@/types';
+import { getTemplateOptionLabels } from '../utils/template-filters';
+import { cn } from '@/lib/utils';
+
+const { Text } = Typography;
+
+export interface TemplateReviewSelectorProps {
+  /** Templates to show as tabs (e.g. for current device). */
+  templates: ClientFlowData[];
+  /** Currently selected template_id. */
+  value: string | null;
+  onChange: (templateId: string) => void;
+  /** Label shown above the tabs (e.g. "Select template to review:"). */
+  label?: React.ReactNode;
+  className?: string;
+  /** Tab size. */
+  size?: 'small' | 'middle' | 'large';
+}
+
+/**
+ * Shared template selector using Ant Design Tabs for review steps (Desktop, Mobile, Final).
+ * Each tab shows the template name; switching tabs shows that template's description below the tab bar.
+ */
+export const TemplateReviewSelector: React.FC<TemplateReviewSelectorProps> = ({
+  templates,
+  value,
+  onChange,
+  label,
+  className,
+  size = 'middle',
+}) => {
+  const activeKey = value ?? templates[0]?.template_id ?? null;
+
+  const tabItems = React.useMemo(
+    () =>
+      templates.map((t) => {
+        const { name } = getTemplateOptionLabels(t);
+        return {
+          key: t.template_id,
+          label: name,
+        };
+      }),
+    [templates]
+  );
+
+  return (
+    <div className={cn('flex flex-col gap-2', className)}>
+      {label != null && (
+        <Text strong className="shrink-0">
+          {label}
+        </Text>
+      )}
+      <Tabs
+        type="line"
+        size={size}
+        activeKey={activeKey ?? undefined}
+        onChange={(key) => onChange(key)}
+        items={tabItems}
+        className="template-review-selector-tabs"
+      />
+    </div>
+  );
+};

--- a/src/features/client-flow/hooks/use-client-flow.ts
+++ b/src/features/client-flow/hooks/use-client-flow.ts
@@ -3,7 +3,6 @@ import { useClientFlowStore } from '@/stores/clientFlowStore';
 import { useDevicesStore } from '@/stores/common/devices.store';
 import { useLoadingStore } from '@/stores/common/loading.store';
 import { useGenericStore } from '@/stores/generic.store';
-import { message } from 'antd';
 
 export const useClientFlow = () => {
   const apiClient = useGenericStore((s) => s.apiClient);
@@ -44,8 +43,6 @@ export const useClientFlow = () => {
       });
       clientFlowActions.setShopperDetails(response);
     } catch (error) {
-      console.error('Error loading shopper details:', error);
-      message.error('Failed to load shopper details');
     } finally {
       loadingActions.setShopperDetailsLoading(false);
     }
@@ -62,8 +59,6 @@ export const useClientFlow = () => {
       const response = await api.templates.getCleintTemplatesData(accountId);
       clientFlowActions.setClientData(response);
     } catch (error) {
-      console.error('Error loading client templates:', error);
-      message.error('Failed to load client templates');
     } finally {
       loadingActions.setClientTemplateDetailsLoading(false);
     }
@@ -77,8 +72,6 @@ export const useClientFlow = () => {
         await api.templateFields.getTemplateFieldsWithContent(accountId);
       clientFlowActions.setContentFields(response);
     } catch (error) {
-      console.error('Error getting fields:', error);
-      message.error('Failed to get fields');
     } finally {
       loadingActions.setContentSubDataLoading(false);
     }
@@ -93,7 +86,6 @@ export const useClientFlow = () => {
       const response = await api.devices.getDevices();
       deviceActions.setDevices(response);
     } catch (error) {
-      message.error('Failed to load devices');
     } finally {
       loadingActions.setDevicesLoading(false);
     }

--- a/src/features/client-flow/screens/CopyReview.tsx
+++ b/src/features/client-flow/screens/CopyReview.tsx
@@ -16,12 +16,10 @@ import ShopperSegmentSelector from '../components/shopper-segment-selector';
  * Redesigned with 2-column layout for better space utilization
  */
 export const CopyReview: React.FC = () => {
-  const accountDetails = useGenericStore((s) => s.accountDetails);
-  const browserPreviewModalOpen = useGenericStore((s) => s.browserPreviewModalOpen);
-  const genericActions = useGenericStore((s) => s.actions);
   const { devices } = useDevicesStore();
   const { getDevices } = useClientFlow();
-  const { clientData } = useClientFlowStore();
+  const { clientData, activeContentShopper } = useClientFlowStore();
+  const activeShopperId = activeContentShopper?.content?.id != null ? Number(activeContentShopper.content.id) : null;
 
   useEffect(() => {
     if (devices.length > 0) return;
@@ -64,7 +62,7 @@ export const CopyReview: React.FC = () => {
         >
           {/* Popup Preview with Desktop/Mobile Tabs - Takes full height */}
           <Card className="h-full">
-            <PopupPreviewTabs clientData={clientData} />
+            <PopupPreviewTabs clientData={clientData} activeShopperId={activeShopperId} />
           </Card>
 
           <Card className='mt-6'>

--- a/src/features/client-flow/types/clientFlow.ts
+++ b/src/features/client-flow/types/clientFlow.ts
@@ -140,6 +140,12 @@ export interface ClientFlowState {
   // field highlighting state
   activeHighlightedField: string | null;
   highlightedFieldName: string | null;
+
+  // selected shopper for content step (CopyReview) and fallback
+  selectedReviewShopperId: number | null;
+
+  // selected template for design review (steps 1, 2, 4) when multiple templates per device — template-based as admin grouped
+  selectedReviewTemplateId: string | null;
 }
 
 export interface ClientFlowActions {
@@ -152,6 +158,8 @@ export interface ClientFlowActions {
 
     // Template Management (API-ready)
     setSelectedTemplate: (template: any) => void;
+    setSelectedReviewShopperId: (id: number | null) => void;
+    setSelectedReviewTemplateId: (id: string | null) => void;
 
     // Error Management
     clearError: () => void;

--- a/src/features/client-flow/utils/template-filters.ts
+++ b/src/features/client-flow/utils/template-filters.ts
@@ -1,0 +1,95 @@
+import { ClientFlowData } from '@/types';
+
+const deviceTypeMatches = (devices: { id: number; device_type: string }[] | undefined, deviceType: 'desktop' | 'mobile'): boolean => {
+  if (!devices?.length) return false;
+  const lower = deviceType.toLowerCase();
+  return devices.some((d) => String(d.device_type).toLowerCase() === lower);
+};
+
+const templateHasShopper = (template: ClientFlowData, shopperId: number): boolean => {
+  const shoppers = template.shoppers ?? [];
+  return shoppers.some((s) => s.id === shopperId);
+};
+
+/**
+ * Returns templates that have the given device type (desktop or mobile).
+ */
+export function getTemplatesForDevice(
+  clientData: ClientFlowData[] | null,
+  deviceType: 'desktop' | 'mobile'
+): ClientFlowData[] {
+  if (!clientData?.length) return [];
+  return clientData.filter((t) => t.staging_status === 'client-review' && deviceTypeMatches(t.devices, deviceType));
+}
+
+/**
+ * Returns templates that have the given device type and the given shopper in their shoppers list.
+ * If shopperId is null/undefined, returns templates for the device only (no shopper filter).
+ */
+export function getTemplatesForDeviceAndShopper(
+  clientData: ClientFlowData[] | null,
+  deviceType: 'desktop' | 'mobile',
+  shopperId: number | null | undefined
+): ClientFlowData[] {
+  const byDevice = getTemplatesForDevice(clientData, deviceType);
+  if (shopperId == null) return byDevice;
+  const withShopper = byDevice.filter((t) => templateHasShopper(t, shopperId));
+  if (withShopper.length > 0) return withShopper;
+  return byDevice;
+}
+
+/**
+ * Returns unique shopper groups from the given templates (dedupe by id).
+ */
+export function getUniqueShoppersFromTemplates(templates: ClientFlowData[]): { id: number; name: string }[] {
+  const map = new Map<number, { id: number; name: string }>();
+  for (const t of templates) {
+    for (const s of t.shoppers ?? []) {
+      if (s.id != null && !map.has(s.id)) map.set(s.id, { id: s.id, name: s.name });
+    }
+  }
+  return Array.from(map.values());
+}
+
+/** Max length for description preview in dropdown options; longer text is truncated with tooltip. */
+export const MAX_DESCRIPTION_PREVIEW_LENGTH = 80;
+
+/**
+ * Display label for a template in the review selector (template-based, as admin grouped it).
+ * Uses template name when set; otherwise "For: [shopper names]".
+ * When includeDescription is true, appends " – [description]" (not used by shared selector; kept for backward compat).
+ */
+export function getTemplateDisplayLabel(
+  template: ClientFlowData,
+  options?: { includeDescription?: boolean }
+): string {
+  const name = template.template_name?.trim();
+  const base =
+    name || (template.shoppers?.length
+      ? `For: ${template.shoppers.map((s) => s.name).join(', ')}`
+      : 'Template');
+  if (options?.includeDescription && template.template_description?.trim()) {
+    return `${base} – ${template.template_description.trim()}`;
+  }
+  return base;
+}
+
+/**
+ * Name and description for template dropdown options. Description is truncated for preview;
+ * use descriptionFull for tooltip. Centralized so selector UI is consistent.
+ */
+export function getTemplateOptionLabels(template: ClientFlowData): {
+  name: string;
+  description: string | null;
+  descriptionFull: string | null;
+} {
+  const name = getTemplateDisplayLabel(template);
+  const raw = template.template_description?.trim() || null;
+  if (!raw) return { name, description: null, descriptionFull: null };
+  const descriptionFull = raw;
+  const description =
+    raw.length <= MAX_DESCRIPTION_PREVIEW_LENGTH
+      ? raw
+      : `${raw.slice(0, MAX_DESCRIPTION_PREVIEW_LENGTH).trim()}…`;
+  return { name, description, descriptionFull };
+}

--- a/src/features/template-builder/components/TemplatesListing.tsx
+++ b/src/features/template-builder/components/TemplatesListing.tsx
@@ -106,7 +106,6 @@ export const TemplatesListing: React.FC<TemplatesListingProps> = ({
       }
     } catch (error) {
       console.error(`Error ${action}ing child template:`, error);
-      message.error(`Failed to ${action} child template`);
     }
   };
 

--- a/src/features/template-builder/components/common/link-template-modal.tsx
+++ b/src/features/template-builder/components/common/link-template-modal.tsx
@@ -58,7 +58,6 @@ export const LinkTemplateModal: React.FC<LinkTemplateModalProps> = ({
       }
     } catch (error) {
       console.error('Error fetching potential child templates:', error);
-      message.error('Failed to load potential child templates');
     } finally {
       setLoading(false);
     }
@@ -84,7 +83,6 @@ export const LinkTemplateModal: React.FC<LinkTemplateModalProps> = ({
       onCancel();
     } catch (error) {
       console.error('Error linking templates:', error);
-      message.error('Failed to link templates');
     } finally {
       setSubmitting(false);
     }

--- a/src/features/template-builder/hooks/use-template-listing.ts
+++ b/src/features/template-builder/hooks/use-template-listing.ts
@@ -72,7 +72,6 @@ export const useTemplateListing = () => {
       }
     } catch (error) {
       console.error(`Error performing ${action}:`, error);
-      message.error(`Failed to ${action} template`);
     }
   };
 
@@ -98,7 +97,6 @@ export const useTemplateListing = () => {
       });
     } catch (error) {
       console.error('Error loading templates:', error);
-      message.error('Failed to load templates');
     } finally {
       loadingActions.setTemplateListingLoading(false);
     }
@@ -215,7 +213,6 @@ export const useTemplateListing = () => {
       }
     } catch (error) {
       console.error('❌ Error publishing template:', error);
-      message.error('Failed to publish template');
     } finally {
       loadingActions.setTemplateListActionLoading(false);
     }
@@ -234,7 +231,6 @@ export const useTemplateListing = () => {
       deviceActions.setDevices(response);
     } catch (error) {
       console.error('Error loading devices:', error);
-      message.error('Failed to load devices');
     } finally {
       loadingActions.setDevicesLoading(false);
     }

--- a/src/lib/hooks/use-template-preview-data.ts
+++ b/src/lib/hooks/use-template-preview-data.ts
@@ -4,7 +4,7 @@ import { createAPI } from '@/api';
 import { CleanTemplateResponse, ClientFlowData } from '@/types';
 import { BaseTemplate } from '@/features/base-template/types';
 import {
-  convertBaseTemplateToClientFlowData,
+  convertTemplateToClientFlowData,
   convertCleanTemplateToClientFlowData,
 } from '@/lib/utils/template-to-client-flow-converter';
 import { useGenericStore } from '@/stores/generic.store';
@@ -117,18 +117,18 @@ export function useTemplatePreviewData(
     };
   }, [storeDevices]);
 
-  // Direct conversion from BaseTemplate (no API call)
+  // Direct conversion from BaseTemplate or CleanTemplateResponse (no API call)
   const directPreviewData = useMemo<ClientFlowData[] | null>(() => {
     if (!enabled || !template) {
       return null;
     }
 
     try {
-      const converted = convertBaseTemplateToClientFlowData(template, htmlContent);
+      const converted = convertTemplateToClientFlowData(template, htmlContent);
       const data = converted ? [converted] : null;
       return data ? mergeDevicesIntoPreviewData(data) : null;
     } catch (err) {
-      console.error('Failed to convert base template:', err);
+      console.error('Failed to convert template to preview data:', err);
       return null;
     }
   }, [template, htmlContent, enabled, mergeDevicesIntoPreviewData]);

--- a/src/lib/utils/retryHelper.ts
+++ b/src/lib/utils/retryHelper.ts
@@ -1,0 +1,32 @@
+/**
+ * Retry an async function with exponential backoff.
+ */
+
+/**
+ * Run an async function, retrying on failure with exponential backoff.
+ * @param fn - Async function to run (no args)
+ * @param maxRetries - Number of retries after the first attempt (default 3)
+ * @param baseDelayMs - Base delay in ms for backoff (default 1000)
+ * @returns Promise resolving with the function result
+ */
+export async function retryWithBackoff<T>(
+  fn: () => Promise<T>,
+  maxRetries = 3,
+  baseDelayMs = 1000
+): Promise<T> {
+  let lastError: Error | undefined;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err instanceof Error ? err : new Error(String(err));
+      if (attempt < maxRetries) {
+        const delay = baseDelayMs * Math.pow(2, attempt) + Math.random() * 500;
+        await new Promise((r) => setTimeout(r, delay));
+      }
+    }
+  }
+
+  throw lastError;
+}

--- a/src/lib/utils/unlayerHelpers.ts
+++ b/src/lib/utils/unlayerHelpers.ts
@@ -1,0 +1,31 @@
+/**
+ * Helpers for Unlayer editor integration.
+ * saveDesignWithTimeout wraps the callback-based saveDesign in a Promise with a timeout.
+ */
+
+/**
+ * Get current design from Unlayer editor with a timeout to avoid hanging forever.
+ * @param editor - Unlayer editor instance (from editorRef.current.editor)
+ * @param timeoutMs - Max wait in ms (default 10000)
+ * @returns Promise resolving with the design JSON, or rejecting on timeout/error
+ */
+export function saveDesignWithTimeout(
+  editor: { saveDesign: (callback: (design: any) => void) => void },
+  timeoutMs = 10000
+): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`saveDesign timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    try {
+      editor.saveDesign((design: any) => {
+        clearTimeout(timer);
+        resolve(design);
+      });
+    } catch (err) {
+      clearTimeout(timer);
+      reject(err);
+    }
+  });
+}

--- a/src/stores/clientFlowStore.ts
+++ b/src/stores/clientFlowStore.ts
@@ -63,6 +63,9 @@ export const useClientFlowStore = create<ClientFlowState & ClientFlowActions>(
     activeHighlightedField: null as string | null,
     highlightedFieldName: null as string | null,
 
+    selectedReviewShopperId: null as number | null,
+    selectedReviewTemplateId: null as string | null,
+
     // ============================================================================
     // ACTIONS (following existing store pattern)
     // ============================================================================
@@ -97,6 +100,14 @@ export const useClientFlowStore = create<ClientFlowState & ClientFlowActions>(
       // Template Management (API-ready)
       setSelectedTemplate: (template: any) => {
         set({ selectedTemplate: template });
+      },
+
+      setSelectedReviewShopperId: (id: number | null) => {
+        set({ selectedReviewShopperId: id });
+      },
+
+      setSelectedReviewTemplateId: (id: string | null) => {
+        set({ selectedReviewTemplateId: id });
       },
 
       // content step


### PR DESCRIPTION
Introduce a custom components framework and UI plus small preview/API fixes. Adds a registry and API for custom components (src/custom-components/registry.ts), three component definitions (product-carousel, two-column-coupon-list, wishlist-progress-bar), design helpers (designUpdater), and developer-facing UI: ComponentGallery, OverlayPropertyPanel, ActiveComponentsList and an index exporter. Also updates template preview logic to use device/shopper-aware filtering and memoization (PopupPreviewTabs), improves BrowserPreviewModal keying and modal teardown, and fixes ContentAPI.getShopperDetails to handle array responses and return the first item. These changes enable injecting/updating custom HTML blocks in Unlayer designs and provide tooling for browsing and editing custom components.